### PR TITLE
fix(python): emit enum discriminators instead of const for Gemini compat

### DIFF
--- a/python/src/adeu/mcp_components/tools/document.py
+++ b/python/src/adeu/mcp_components/tools/document.py
@@ -12,7 +12,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from fastmcp.tools.tool import ToolResult
-from pydantic import TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from adeu.diff import generate_edits_from_text
 from adeu.ingest import _extract_text_from_doc, extract_text_from_stream
@@ -38,6 +38,7 @@ from adeu.models import (
     RejectChange,
     ReplyComment,
     coerce_stringified_changes,
+    const_to_enum,
 )
 from adeu.redline.engine import BatchValidationError, RedlineEngine
 from adeu.utils.docx import strip_bom_from_docx_bytes
@@ -547,11 +548,15 @@ if sys.platform == "win32":
         ] = "full",
         page: Annotated[
             Optional[Union[int, Literal["all"]]],
-            (
-                "Without `search_query`: 1-indexed document page to display (defaults to 1) "
-                "for mode='full' and mode='appendix'. With `search_query`: restricts matches "
-                "to that document page (defaults to searching all pages; pass `page='all'` "
-                "to be explicit). 'all' is also valid in CLI."
+            Field(
+                description=(
+                    "Without `search_query`: 1-indexed document page to display (defaults to 1) "
+                    "for mode='full' and mode='appendix'. With `search_query`: restricts matches "
+                    "to that document page (defaults to searching all pages; pass `page='all'` "
+                    "to be explicit). 'all' is also valid in CLI."
+                ),
+                # Render Literal["all"] as enum, not const, for Gemini. See issue #37.
+                json_schema_extra=const_to_enum,
             ),
         ] = None,
         outline_max_level: Annotated[
@@ -810,10 +815,14 @@ else:
         ] = "full",
         page: Annotated[
             Optional[Union[int, Literal["all"]]],
-            (
-                "Without `search_query`: 1-indexed document page to display (defaults to 1) "
-                "for mode='full'. With `search_query`: restricts matches to that document "
-                "page (defaults to searching all pages; pass `page='all'` to be explicit)."
+            Field(
+                description=(
+                    "Without `search_query`: 1-indexed document page to display (defaults to 1) "
+                    "for mode='full'. With `search_query`: restricts matches to that document "
+                    "page (defaults to searching all pages; pass `page='all'` to be explicit)."
+                ),
+                # Render Literal["all"] as enum, not const, for Gemini. See issue #37.
+                json_schema_extra=const_to_enum,
             ),
         ] = None,
         outline_max_level: Annotated[

--- a/python/src/adeu/models.py
+++ b/python/src/adeu/models.py
@@ -6,6 +6,33 @@ from pydantic import BaseModel, BeforeValidator, Field, PrivateAttr
 from adeu.redline.mapper import DocumentMapper
 
 
+def const_to_enum(schema: Any) -> None:
+    """Recursively rewrite JSON-Schema ``const`` to a one-member ``enum``.
+
+    Pydantic v2 serializes a single-value ``Literal["x"]`` to ``{"const": "x"}``.
+    Gemini's function-calling API rejects ``const`` outright, so any Gemini-based
+    client hitting this server fails — most visibly on the
+    ``process_document_batch.changes`` discriminator (a ``Literal`` per variant),
+    but also on plain literals nested in unions such as ``read_docx``'s
+    ``page`` (``Literal["all"]``). ``{"enum": ["x"]}`` is semantically identical
+    (a one-member enum) and is accepted everywhere, matching how the Node server
+    declares these. See issue #37.
+
+    Designed to be passed as a Pydantic ``json_schema_extra`` callable: it mutates
+    the field's schema dict in place and recurses into nested ``anyOf``/``oneOf``
+    branches. Validation behaviour is unchanged — Pydantic still enforces the
+    underlying ``Literal``.
+    """
+    if isinstance(schema, dict):
+        if "const" in schema:
+            schema["enum"] = [schema.pop("const")]
+        for value in schema.values():
+            const_to_enum(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            const_to_enum(item)
+
+
 class EditOperationType:
     """Internal enum for low-level XML manipulation"""
 
@@ -21,7 +48,11 @@ class ModifyText(BaseModel):
     The engine treats this as a "Search and Replace" operation.
     """
 
-    type: Literal["modify"] = Field("modify", description="Must be 'modify' for text replacements.")
+    type: Literal["modify"] = Field(
+        "modify",
+        description="Must be 'modify' for text replacements.",
+        json_schema_extra=const_to_enum,
+    )
 
     target_text: str = Field(
         ...,
@@ -66,25 +97,37 @@ class ModifyText(BaseModel):
 
 
 class AcceptChange(BaseModel):
-    type: Literal["accept"] = Field("accept", description="Must be 'accept' to finalize a tracked change.")
+    type: Literal["accept"] = Field(
+        "accept",
+        description="Must be 'accept' to finalize a tracked change.",
+        json_schema_extra=const_to_enum,
+    )
     target_id: str = Field(..., description="The full ID string from the document text (e.g. 'Chg:12').")
     comment: Optional[str] = Field(None, description="Optional rationale.")
 
 
 class RejectChange(BaseModel):
-    type: Literal["reject"] = Field("reject", description="Must be 'reject' to revert a tracked change.")
+    type: Literal["reject"] = Field(
+        "reject",
+        description="Must be 'reject' to revert a tracked change.",
+        json_schema_extra=const_to_enum,
+    )
     target_id: str = Field(..., description="The full ID string from the document text (e.g. 'Chg:12').")
     comment: Optional[str] = Field(None, description="Optional rationale.")
 
 
 class ReplyComment(BaseModel):
-    type: Literal["reply"] = Field("reply", description="Must be 'reply' to respond to a comment.")
+    type: Literal["reply"] = Field(
+        "reply",
+        description="Must be 'reply' to respond to a comment.",
+        json_schema_extra=const_to_enum,
+    )
     target_id: str = Field(..., description="The full ID string from the document text (e.g. 'Com:5').")
     text: str = Field(..., description="The content of the reply body.")
 
 
 class InsertTableRow(BaseModel):
-    type: Literal["insert_row"] = Field("insert_row")
+    type: Literal["insert_row"] = Field("insert_row", json_schema_extra=const_to_enum)
 
     target_text: str = Field(
         ...,
@@ -114,7 +157,7 @@ class InsertTableRow(BaseModel):
 
 
 class DeleteTableRow(BaseModel):
-    type: Literal["delete_row"] = Field("delete_row")
+    type: Literal["delete_row"] = Field("delete_row", json_schema_extra=const_to_enum)
 
     target_text: str = Field(
         ...,

--- a/python/tests/test_gemini_schema_compat.py
+++ b/python/tests/test_gemini_schema_compat.py
@@ -1,0 +1,74 @@
+# FILE: tests/test_gemini_schema_compat.py
+"""Regression tests for issue #37.
+
+Gemini's function-calling API rejects JSON-Schema ``const``. Pydantic v2 emits
+``const`` for single-value ``Literal`` types — most importantly the ``type``
+discriminator on every ``DocumentChange`` variant exposed through
+``process_document_batch.changes``, and ``read_docx``'s ``page`` (``Literal["all"]``).
+These tests assert the published tool schemas use ``enum`` instead, so a
+Gemini-based client can call the Python server directly.
+"""
+
+import asyncio
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from adeu.models import DocumentChange, const_to_enum
+
+
+def _find_const(node) -> bool:
+    """True if ``const`` appears anywhere in the (nested) schema."""
+    if isinstance(node, dict):
+        if "const" in node:
+            return True
+        return any(_find_const(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_find_const(v) for v in node)
+    return False
+
+
+def test_const_to_enum_rewrites_top_level():
+    schema = {"const": "modify", "type": "string"}
+    const_to_enum(schema)
+    assert schema == {"enum": ["modify"], "type": "string"}
+
+
+def test_const_to_enum_rewrites_nested_union():
+    schema = {"anyOf": [{"type": "integer"}, {"const": "all", "type": "string"}]}
+    const_to_enum(schema)
+    assert schema == {"anyOf": [{"type": "integer"}, {"enum": ["all"], "type": "string"}]}
+
+
+def test_document_change_discriminators_use_enum_not_const():
+    schema = TypeAdapter(list[DocumentChange]).json_schema()
+    for name, definition in schema["$defs"].items():
+        type_field = definition["properties"]["type"]
+        assert "const" not in type_field, f"{name}.type still emits const"
+        assert "enum" in type_field, f"{name}.type missing enum"
+        assert len(type_field["enum"]) == 1
+    assert not _find_const(schema)
+
+
+def test_no_tool_schema_emits_const():
+    """No published MCP tool schema may contain `const` (Gemini rejects it)."""
+    from adeu.server import mcp
+
+    tools = asyncio.run(mcp.list_tools())
+    offenders = [t.name for t in tools if getattr(t, "parameters", None) and _find_const(t.parameters)]
+    assert not offenders, f"tools still emit const discriminators: {offenders}"
+
+
+def test_discriminated_union_still_validates():
+    """Rewriting const->enum must not weaken validation."""
+    ta = TypeAdapter(list[DocumentChange])
+    parsed = ta.validate_python(
+        [
+            {"type": "accept", "target_id": "Chg:1"},
+            {"type": "modify", "target_text": "a", "new_text": "b"},
+        ]
+    )
+    assert [type(p).__name__ for p in parsed] == ["AcceptChange", "ModifyText"]
+
+    with pytest.raises(ValidationError):
+        ta.validate_python([{"type": "not_a_real_type"}])


### PR DESCRIPTION
## Summary

Fixes #37.

Pydantic v2 serializes single-value `Literal` types to JSON-Schema `const`, which Gemini's function-calling API rejects outright. This affected:

- **`process_document_batch.changes`** — the `type` discriminator on every `DocumentChange` variant (`modify`, `accept`, `reject`, `reply`, `insert_row`, `delete_row`).
- **`read_docx.page`** — `Literal["all"]` nested inside the union.

Any Gemini-based client hitting the Python server directly would fail on these; the benchmark only worked because the harness was patched to coerce `const`→`enum`. The Node server avoids this by declaring the discriminator as `enum`.

## Fix

Added a reusable `const_to_enum` helper passed as Pydantic's `json_schema_extra` callable. It rewrites `const` to a semantically identical one-member `enum`, recursing into nested `anyOf`/`oneOf` branches (needed for `page`'s union). Validation behaviour is unchanged — Pydantic still enforces the underlying `Literal`.

## Changes

- `python/src/adeu/models.py` — `const_to_enum` helper + applied to all 6 discriminator fields.
- `python/src/adeu/mcp_components/tools/document.py` — applied to both `read_docx.page` declarations (Live Word / disk branches).
- `python/tests/test_gemini_schema_compat.py` — new regression tests: no tool schema emits `const`, helper works on top-level and nested cases, and the discriminated union still validates (and still rejects bad discriminators).

## Verification

- `0` `const` occurrences across all live MCP tool schemas.
- Full suite: 460 passed / 30 skipped.
- `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01594Ke2SoKMQMA992S4y42u

---
_Generated by [Claude Code](https://claude.ai/code/session_01594Ke2SoKMQMA992S4y42u)_