### PR TITLE
ci(release): consistency gate and smoother release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           node-version: "24.x"
 
+      # Gate the whole release on codex integrity + monorepo version lockstep
+      # BEFORE any asset is built or published. Mirrors the check enforced in
+      # CI / pre-push, so a bad tag fails here instead of shipping.
+      - name: Validate release consistency
+        run: node scripts/check_release_consistency.mjs
+
       - name: Install Dependencies
         working-directory: ./node
         run: npm install
@@ -34,16 +40,6 @@ jobs:
       - name: Pack MCPB Bundle
         working-directory: ./desktop-extension
         run: zip -r Adeu.mcpb manifest.json icon.png package.json *.js assets/ templates/
-
-      - name: Build Smithery Bundle
-        run: python scripts/patch_smithery_mcpb.py
-
-      - name: Publish to Smithery
-        env:
-          SMITHERY_API_KEY: ${{ secrets.SMITHERY_TOKEN }}
-        # Using --yes to suppress any interactive CLI prompts
-        run: |
-          npx --yes smithery@latest mcp publish adeu-smithery.mcpb -n adeu/adeu
 
       - name: Generate Draft Release and Upload Asset
         env:
@@ -85,10 +81,50 @@ jobs:
             ./linux.adeu.zip \
             ./win32.adeu.zip
 
+  smithery-publish:
+    # Smithery ships on the SAME trigger as npm/PyPI (release published), not at
+    # the draft/tag stage — otherwise tagging a release you never publish would
+    # still push to Smithery, skewing it ahead of the other registries.
+    if: github.repository == 'dealfluence/adeu' && github.event_name == 'release'
+    name: Publish to Smithery
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+
+      - name: Install Dependencies
+        working-directory: ./node
+        run: npm install
+
+      - name: Build Packages
+        working-directory: ./node
+        run: npm run build
+
+      - name: Build Smithery Bundle
+        run: python scripts/patch_smithery_mcpb.py
+
+      - name: Publish to Smithery
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_TOKEN }}
+        # Using --yes to suppress any interactive CLI prompts
+        run: |
+          npx --yes smithery@latest mcp publish adeu-smithery.mcpb -n adeu/adeu
+
   pypi-publish:
     if: github.repository == 'dealfluence/adeu' && github.event_name == 'release'
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    # The `pypi` environment is intentionally a NAME-ONLY reference, not a
+    # second approval gate. PyPI's OIDC Trusted Publisher is pinned to this
+    # exact environment name, so the `environment:` block must stay for auth to
+    # succeed — do NOT delete it. The single human gate is the GitHub Release
+    # draft -> Publish click. If you want to pause this job again, add a
+    # "Required reviewers" protection rule under Settings -> Environments ->
+    # pypi (repo settings), NOT here.
     environment:
       name: pypi
       url: https://pypi.org/p/adeu
@@ -165,6 +201,10 @@ jobs:
     if: github.repository == 'dealfluence/adeu' && github.event_name == 'release'
     name: Upload langchain-adeu to PyPI
     runs-on: ubuntu-latest
+    # Same as the `pypi` job: name-only environment pinned by langchain-adeu's
+    # OIDC Trusted Publisher. Keep the `environment:` block (required for auth);
+    # it is not an approval gate. Re-add a gate via Settings -> Environments ->
+    # langchain-pypi if ever needed, not in this file.
     environment:
       name: langchain-pypi
       url: https://pypi.org/project/langchain-adeu

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -157,6 +157,9 @@ To solve domain visibility gaps without adding new MCP tools, `read_docx` projec
 ### Deployment
 *   **Versioning**: Semantic versioning in `pyproject.toml`. `src/adeu/__init__.py` dynamically loads this via `importlib.metadata`.
 *   **Dependencies**: Uses `uv` (PEP 621 standard) with `hatchling` as the build backend. `python-docx` is patched at runtime in `comments.py` to support Modern Comments namespaces (`w16cid`, `w15`).
+*   **Release pipeline** (`.github/workflows/release.yml`): Two-phase. Run `scripts/bump.py X.Y.Z` (syncs manifests + lockfiles), commit, then push a `vX.Y.Z` tag — the tag triggers `draft-release` (build + draft GitHub Release). A human then clicks **Publish**, which fires the `npm` / `pypi` / `langchain-pypi` / `smithery` jobs.
+    *   *Consistency gate*: `scripts/check_release_consistency.mjs` is the single source of truth for codex integrity (n8n `nodeVersion`/`codexVersion`/`node`/categories) + monorepo version lockstep. It runs in CI/pre-push (via a vitest test in `n8n-nodes-adeu`), inside `bump.py`, and as the first step of `draft-release` — a bad tag fails before any asset ships.
+    *   *Manual gates*: the only human gate is the draft → **Publish** click. The `pypi`/`langchain-pypi` GitHub Environments are name-only OIDC pins (Trusted Publishing), NOT approval gates — keep the `environment:` blocks; add a "Required reviewers" rule in repo Settings → Environments to re-gate. Smithery publishes on the **publish** event (not at tag/draft time) so all registries ship together.
 
 ### Agent Integration Testing
 *   To test changes to the MCP server without publishing to PyPI, use `uv run adeu init --local`.

--- a/node/packages/n8n-nodes-adeu/test/codex-consistency.test.ts
+++ b/node/packages/n8n-nodes-adeu/test/codex-consistency.test.ts
@@ -1,0 +1,23 @@
+// FILE: test/codex-consistency.test.ts
+//
+// Guards the n8n codex file + monorepo version lockstep. The actual rules live
+// in scripts/check_release_consistency.mjs (single source of truth, also run
+// as the first gate of the Release workflow); this test wires them into the
+// node test suite so CI and the pre-push hook fail fast on any drift.
+//
+// Background: n8n Cloud verification once rejected a release because
+// Adeu.node.json's `nodeVersion` had been bumped to the npm package version
+// instead of mirroring the node class's `version`. This test makes that class
+// of mistake impossible to merge.
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { runChecks } from "../../../../scripts/check_release_consistency.mjs";
+
+describe("Release consistency", () => {
+  it("codex file and monorepo versions are internally consistent", () => {
+    const repoRoot = resolve(__dirname, "../../../..");
+    const { errors } = runChecks(repoRoot);
+    expect(errors).toEqual([]);
+  });
+});

--- a/scripts/bump.py
+++ b/scripts/bump.py
@@ -137,18 +137,40 @@ def main():
     print("   Running 'npm install --package-lock-only' in node/...")
     run_cmd(["npm", "install", "--package-lock-only"], cwd="node", check=False)
 
+    print("\n🔎 Verifying release consistency...")
+    try:
+        check = run_cmd(
+            ["node", "scripts/check_release_consistency.mjs"], check=False
+        )
+        print(check.stdout.strip() or check.stderr.strip())
+        if check.returncode != 0:
+            print(
+                "\n⚠️  Consistency check FAILED — resolve the issues above before tagging."
+            )
+    except FileNotFoundError:
+        print(
+            "  ! node not found — skipping consistency check"
+            " (CI re-runs it before the release builds)."
+        )
+
+    tag = f"v{target_version}"
     print("\n🎉 Files and lockfiles updated successfully!")
     print("\nNext steps:")
     print("  1. Review changes: git diff")
     print(f'  2. git commit -am "chore(release): bump version to {target_version}"')
     print("  3. git push origin main")
+    print("  4. Tag the release — THIS push is what triggers the pipeline:")
+    print(f'       git tag -a {tag} -m "Release {tag}"')
+    print(f"       git push origin {tag}")
     print(
-        "  ⚠️  Do NOT sync nodeVersion/codexVersion in nodes/Adeu/Adeu.node.json"
-        " to this package version. nodeVersion mirrors Adeu.node.ts's `version`"
-        " (now \"1.0\"); codexVersion is the schema version (\"1.0\")."
+        "  5. CI builds the draft release + assets. Add notes, then click 'Publish'"
+        " to ship to npm / PyPI / Smithery."
     )
     print(
-        "  4. Wait for CI to create the Draft Release, then go to GitHub to add notes and click 'Publish'"
+        "\n  ⚠️  Do NOT sync nodeVersion/codexVersion in nodes/Adeu/Adeu.node.json"
+        " to this package version. nodeVersion mirrors Adeu.node.ts's `version`"
+        ' (now "1.0"); codexVersion is the schema version ("1.0"). The'
+        " consistency check above enforces this."
     )
 
 

--- a/scripts/check_release_consistency.mjs
+++ b/scripts/check_release_consistency.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Release consistency checker (zero-dependency, single source of truth).
+//
+// Two independent guarantees, both of which have bitten us before:
+//
+//   1. n8n codex integrity — nodes/Adeu/Adeu.node.json must agree with the
+//      node class in Adeu.node.ts. n8n Cloud verification rejects a codex
+//      whose `nodeVersion` does not mirror the node's runtime `version`, or
+//      whose `codexVersion` is anything but the schema version "1.0".
+//   2. Monorepo version lockstep — every manifest bumped by scripts/bump.py
+//      must carry the exact same semantic version.
+//
+// Run directly to gate a release (exits non-zero on any failure):
+//     node scripts/check_release_consistency.mjs
+// Or import { runChecks } from a test to enforce it in CI / pre-push.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Valid n8n node categories (see node-codex-files docs). Keep in sync with
+// https://docs.n8n.io/integrations/creating-nodes/build/reference/node-codex-files/
+const VALID_CATEGORIES = new Set([
+  "Data & Storage",
+  "Finance & Accounting",
+  "Marketing & Content",
+  "Productivity",
+  "Miscellaneous",
+  "Sales",
+  "Development",
+  "Analytics",
+  "Communication",
+  "Utility",
+]);
+
+// Manifests synchronized to one version by scripts/bump.py. KEEP IN SYNC with
+// FILES_TO_BUMP there — this check is what catches it if they drift.
+const VERSIONED_MANIFESTS = [
+  "python/pyproject.toml",
+  "langchain/pyproject.toml",
+  "node/packages/core/package.json",
+  "node/packages/mcp-server/package.json",
+  "desktop-extension/manifest.json",
+  "gemini-extension.json",
+  "python/server.json",
+  "node/packages/n8n-nodes-adeu/package.json",
+];
+
+const N8N_DIR = "node/packages/n8n-nodes-adeu";
+
+function readVersionFromManifest(text, filepath) {
+  // .toml uses `version = "x"`; .json uses `"version": "x"`.
+  const re = filepath.endsWith(".toml")
+    ? /^version\s*=\s*"([^"]+)"/m
+    : /"version"\s*:\s*"([^"]+)"/;
+  const m = text.match(re);
+  return m ? m[1] : null;
+}
+
+/**
+ * Run all release-consistency checks against a repo root.
+ * @returns {{errors: string[]}}
+ */
+export function runChecks(repoRoot) {
+  const errors = [];
+  const read = (rel) => readFileSync(resolve(repoRoot, rel), "utf8");
+
+  // --- Check 1: n8n codex integrity ---------------------------------------
+  try {
+    const nodeTs = read(`${N8N_DIR}/nodes/Adeu/Adeu.node.ts`);
+    const codex = JSON.parse(read(`${N8N_DIR}/nodes/Adeu/Adeu.node.json`));
+    const pkg = JSON.parse(read(`${N8N_DIR}/package.json`));
+
+    const nameMatch = nodeTs.match(/name:\s*"([^"]+)"/);
+    const versionMatch = nodeTs.match(/version:\s*(\d+(?:\.\d+)?)/);
+
+    if (!nameMatch || !versionMatch) {
+      errors.push(
+        "codex: could not parse `name`/`version` from Adeu.node.ts — update the checker if the node class changed shape.",
+      );
+    } else {
+      const nodeName = nameMatch[1];
+      const nodeVersion = parseFloat(versionMatch[1]);
+
+      // nodeVersion mirrors the class version, formatted x.y (e.g. 1 -> "1.0").
+      if (!/^\d+\.\d+$/.test(String(codex.nodeVersion))) {
+        errors.push(
+          `codex.nodeVersion must be an "x.y" string, got ${JSON.stringify(codex.nodeVersion)}.`,
+        );
+      }
+      if (parseFloat(codex.nodeVersion) !== nodeVersion) {
+        errors.push(
+          `codex.nodeVersion (${JSON.stringify(codex.nodeVersion)}) must mirror Adeu.node.ts version (${nodeVersion}). ` +
+            `It is NOT the npm package version — do not sync it to ${pkg.version}.`,
+        );
+      }
+
+      if (codex.codexVersion !== "1.0") {
+        errors.push(
+          `codex.codexVersion must be the schema version "1.0", got ${JSON.stringify(codex.codexVersion)}.`,
+        );
+      }
+
+      const expectedNode = `n8n-nodes-adeu.${nodeName}`;
+      if (codex.node !== expectedNode) {
+        errors.push(
+          `codex.node must be "${expectedNode}" (package "${pkg.name}" + node name "${nodeName}"), got ${JSON.stringify(codex.node)}.`,
+        );
+      }
+    }
+
+    if (!Array.isArray(codex.categories) || codex.categories.length === 0) {
+      errors.push("codex.categories must be a non-empty array.");
+    } else {
+      for (const c of codex.categories) {
+        if (!VALID_CATEGORIES.has(c)) {
+          errors.push(
+            `codex.categories has invalid entry ${JSON.stringify(c)} — must be one of: ${[...VALID_CATEGORIES].join(", ")}.`,
+          );
+        }
+      }
+    }
+  } catch (e) {
+    errors.push(`codex: failed to read/parse n8n files — ${e.message}`);
+  }
+
+  // --- Check 2: monorepo version lockstep ---------------------------------
+  const versions = {};
+  for (const rel of VERSIONED_MANIFESTS) {
+    try {
+      const v = readVersionFromManifest(read(rel), rel);
+      if (!v) {
+        errors.push(`lockstep: no version found in ${rel}.`);
+      } else {
+        versions[rel] = v;
+      }
+    } catch (e) {
+      errors.push(`lockstep: failed to read ${rel} — ${e.message}`);
+    }
+  }
+  const distinct = [...new Set(Object.values(versions))];
+  if (distinct.length > 1) {
+    const detail = Object.entries(versions)
+      .map(([f, v]) => `    ${v}  ${f}`)
+      .join("\n");
+    errors.push(
+      `lockstep: manifests are not all on the same version:\n${detail}\n  Run scripts/bump.py to resynchronize.`,
+    );
+  }
+
+  return { errors };
+}
+
+// CLI entry point.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const { errors } = runChecks(repoRoot);
+  if (errors.length) {
+    console.error("✖ Release consistency checks FAILED:\n");
+    for (const e of errors) console.error(`  • ${e}`);
+    console.error("");
+    process.exit(1);
+  }
+  console.log("✓ Release consistency checks passed.");
+}


### PR DESCRIPTION
## Pull Request Overview

Hardens and smooths the release pipeline. This is the follow-on to the n8n codex `nodeVersion` fix (already merged) — it makes that class of bug impossible to reintroduce and tidies the release flow.

**What's included**

- **Single source of truth for validation** — `scripts/check_release_consistency.mjs` (zero-dependency Node). Two guarantees:
  1. *n8n codex integrity*: `nodeVersion` mirrors the node class `version` in `Adeu.node.ts` (currently `1` → `"1.0"`), `codexVersion === "1.0"`, `node === "n8n-nodes-adeu.<name>"`, and `categories` are all valid n8n categories.
  2. *Monorepo version lockstep*: every manifest bumped by `bump.py` shares one version.
- **Enforced in three places** off that one check:
  - *Dev loop*: a Vitest test (`test/codex-consistency.test.ts`) wires it into CI's `node-test` job and the `pre-push` hook.
  - *Release time*: it's the first step of `draft-release`, before any asset is built — a bad tag fails before it ships.
  - *Bump time*: `bump.py` runs it after bumping.
- **Smithery moved to the publish phase** — was publishing at tag/draft time, which meant tagging a release you never publish would still push to Smithery, skewing it ahead of npm/PyPI. Now it's a `smithery-publish` job on `release: published`, so all registries ship together on the Publish click.
- **`bump.py`** now prints the explicit `git tag` / `git push` steps (the tag is what triggers the pipeline — previously undocumented).
- **Docs** — `AI_CONTEXT.md` describes the release flow, the manual gate, and the `pypi`/`langchain-pypi` environments (name-only OIDC pins for Trusted Publishing, **not** approval gates — comments added inline in `release.yml` so nobody deletes the `environment:` block or re-adds a reviewer rule by accident).

The release trigger is unchanged: `bump.py` → commit → push a `vX.Y.Z` tag → draft build → click **Publish**.

---

## 🛑 Ecosystem / Vendor Integrations (READ FIRST)
Not applicable — this PR does not add or modify anything under `ecosystem/`.

---

## 🛠️ Core Engine Contributions
This PR is CI/release tooling only; it does not touch the OpenXML engine.

- [x] Added a test (`test/codex-consistency.test.ts`) that enforces codex + version-lockstep consistency. Verified it goes green on the repo and red on the original `nodeVersion: "1.17"` regression.
- [x] N/A — no `RedlineEngine` changes.
- [x] Node suite passes (`n8n-nodes-adeu`: 17/17). No `src/` Python changes, so `ruff`/`mypy` are unaffected.
- [x] N/A — no Live MS Word / COM changes.

## Related Issues
n8n Cloud verification feedback (codex `nodeVersion` must be `"1.0"`). No tracked issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)