### PR TITLE
docs: document email/cloud MCP tools, update stale LangChain/contributor docs

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -166,6 +166,11 @@ To solve domain visibility gaps without adding new MCP tools, `read_docx` projec
 *   This configures Claude Desktop to execute the server from the current local source (`sys.executable` + `cwd`), bypassing `uvx`.
 
 ## Current Status
+
+> **Note:** The changelog below is not exhaustive — the latest entry is v1.14.0 while the project
+> is currently at **v1.18.4**. See [GitHub Releases](https://github.com/dealfluence/adeu/releases)
+> for the full release history.
+
 - **v1.14.0**: Search & Targeted Write Engine Upgrade.
     - Introduced flat `search_query` and `regex` filters directly on the `read_docx` endpoint.
     - Added `match_mode` (`"strict"`, `"first"`, `"all"`) and `regex` parameters to `ModifyText` for highly targeted, multi-occurrence writing workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Thank you for your interest in contributing to Adeu! We welcome bug reports, fea
 
 ## Development Environment
 
-Adeu relies on Python toolchain managed by [uv](https://docs.astral.sh/uv/).
+Adeu is a monorepo with a Python backend, a Node.js workspace, and a LangChain integration package. The Python toolchain is managed by [uv](https://docs.astral.sh/uv/); the Node.js workspace uses npm. You need Python >=3.12 and Node.js >=22.0.0.
 
-### 1. Setup
+### 1. Python Setup
 
-Clone the repository and install the dependencies:
+Clone the repository and install the Python dependencies:
 
 ```bash
 git clone https://github.com/dealfluence/adeu.git
@@ -75,6 +75,31 @@ cd python && uv run pytest --cov=src
 ```
 
 *(Note: Tests involving the Live Word COM engine are automatically skipped on non-Windows platforms).*
+
+### 4. Node.js Setup
+
+Install and build the Node.js workspace:
+
+```bash
+cd node
+npm install
+npm run build     # build all packages (tsup)
+npm run test      # run all vitest suites
+```
+
+The Node workspace contains three packages: `@adeu/core` (TypeScript SDK), `@adeu/mcp-server` (MCP server), and `n8n-nodes-adeu` (n8n community node).
+
+### 5. LangChain Setup
+
+```bash
+cd langchain
+uv sync --all-extras --dev
+uv run pytest                           # unit tests
+uv run ruff format . && uv run ruff check . --fix
+uv run mypy .
+```
+
+The LangChain package uses `uv.sources` to editable-link the sibling `python/` package during local development.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -196,18 +196,15 @@ See the [n8n-nodes-adeu README](https://github.com/dealfluence/adeu/blob/main/no
 
 ---
 
-## LangChain Integration (Work in Progress)
+## LangChain Integration
 
-We are developing `langchain-adeu`, an official integration package that exposes Adeu's local, offline-capable document manipulation tools directly to the LangChain ecosystem. 
+`langchain-adeu` is an official integration package that exposes Adeu's local, offline-capable document manipulation tools directly to the LangChain ecosystem.
 
-> 🚧 **Pre-release Warning:** This integration is currently a work in progress and has not yet been published to the official PyPI registry.
-
-Once published, you will be able to install it via:
 ```bash
 pip install langchain-adeu
 ```
 
-And bundle its capabilities as tools in your agent workflow:
+Bundle its capabilities as tools in your agent workflow:
 ```python
 from langchain_adeu import AdeuToolkit
 
@@ -223,10 +220,7 @@ Refer to the [LangChain Workspace Guide](langchain/README.md) for full developme
 
 Adeu is designed as a Virtual DOM for DOCX. Because we keep the core strictly focused on OpenXML safety, we maintain a dedicated [`ecosystem/`](ecosystem/) directory for third-party integrations.
 
-In the ecosystem folder, you will find advanced workflows, wrappers, and tools built by the community and LegalTech vendors, including:
-- Legal validation and case-law routing before applying edits.
-- Contract Lifecycle Management (CLM) sync scripts.
-- Specialized multi-agent architectures (LangChain, AutoGen, etc.).
+The ecosystem folder hosts policies and guidelines for third-party contributions such as legal validation workflows, CLM sync scripts, and specialized multi-agent architectures.
 
 **Are you a vendor or builder?** We welcome PRs to the ecosystem folder! Please see our [Vendor & Integration Policy](ecosystem/VENDOR_POLICY.md) to get started.
 

--- a/node/packages/mcp-server/README.md
+++ b/node/packages/mcp-server/README.md
@@ -30,13 +30,28 @@ Add the following to your MCP configuration file (`claude_desktop_config.json`):
 
 ## Exposed Tools
 
-Once connected, your AI agent will have access to the following tools:
+Once connected, your AI agent will have access to the following tools.
+
+### Document tools
 
 - `read_docx`: Reads a DOCX file and returns LLM-friendly text with inline CriticMarkup (`{++inserted++}`, `{--deleted--}`) for Tracked Changes and Comments. Supports pagination, structural outlining, and semantic appendix extraction.
 - `process_document_batch`: Applies a batch of search-and-replace text modifications, table edits, and comment replies to a document. Translates the LLM's edits into perfectly formatted native Word Track Changes.
 - `accept_all_changes`: Accepts all tracked changes and removes all comments to produce a finalized clean document.
 - `diff_docx_files`: Compares two DOCX files and returns a unified sub-word diff of their text content.
 - `finalize_document`: Prepares a document for signature by applying native OOXML read-only locking and deep metadata sanitization.
+
+### Email tools
+
+These require an authenticated Adeu Cloud session (see Cloud tools below).
+
+- `search_and_fetch_emails`: Searches the user's live email inbox via the Adeu Cloud backend and returns matching messages.
+- `create_email_draft`: Creates an email draft in the user's native draft box (Outlook Drafts or Gmail Drafts).
+- `list_available_mailboxes`: Lists all personal and shared/delegated mailboxes the authenticated user can access across every linked provider account, including each mailbox's address, display name, and auto-processing settings.
+
+### Cloud tools
+
+- `login_to_adeu_cloud`: Logs the user into Adeu Cloud, opening a browser window for SSO authentication.
+- `logout_of_adeu_cloud`: Logs out of the Adeu Cloud backend.
 
 ## Documentation & Support
 For full architectural details, prompt recommendations, and the project constitution, please visit the [main Adeu repository](https://github.com/dealfluence/adeu) or our [website](https://adeu.ai).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -64,7 +64,7 @@ artifacts = [
 ]
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "W"]


### PR DESCRIPTION
## Summary

Documentation-accuracy fixes plus one small config alignment:

- **node/packages/mcp-server/README.md** — the "Exposed Tools" list only covered the 5 document tools. This adds the email tools (`search_and_fetch_emails`, `create_email_draft`, `list_available_mailboxes`) and Adeu Cloud auth tools (`login_to_adeu_cloud`, `logout_of_adeu_cloud`) that the server registers, grouped into Document / Email / Cloud sections. All tool names verified against `src/index.ts` registrations.
- **README.md** — `langchain-adeu` is published on PyPI (currently 1.18.4), so the "Work in Progress" heading and pre-release warning are stale; removed. Also reworded the ecosystem section: the `ecosystem/` folder currently hosts policy docs, not contributed integrations.
- **CONTRIBUTING.md** — setup only covered the Python workspace; added Node.js and LangChain workspace setup sections.
- **AI_CONTEXT.md** — added a note that the changelog's latest entry is v1.14.0 while the project is at v1.18.4, pointing to GitHub Releases.
- **python/pyproject.toml** — ruff `target-version` was `py310` but `requires-python` is `>=3.12`; aligned to `py312`. `uv run ruff check .` passes.

## Test plan

- Docs-only changes plus a lint-config value; ran `uv run ruff check .` in `python/` — all checks pass.