### PR TITLE
Remove the undocumented pre-v1.1.0 legacy CLI batch format

### DIFF
--- a/node/packages/core/src/engine.ts
+++ b/node/packages/core/src/engine.ts
@@ -605,8 +605,8 @@ export class RedlineEngine {
    * Snapshots the document text around a resolved edit BEFORE anything is
    * applied. Previews rendered after the batch mutates the DOM cannot slice
    * full_text at the stored offsets: applied edits shift offsets and inject
-   * tracked-change markup, which produced garbled previews mixing unrelated
-   * edits and internal scaffolding (QA H1).
+   * tracked-change markup, garbling previews with unrelated edits and
+   * internal scaffolding (QA H1).
    */
   private _capture_preview_context(edit: any): void {
     if (edit.type !== "modify") return;
@@ -724,8 +724,8 @@ export class RedlineEngine {
 
   /**
    * The "new text" a batch report should show for an edit. InsertTableRow has
-   * no new_text field — surface its cell contents instead of the misleading
-   * empty string the report used to print (QA M4).
+   * no new_text field — surface its cell contents rather than a misleading
+   * empty string (QA M4).
    */
   private static _report_new_text(edit: any): string {
     if (edit && edit.type === "insert_row" && Array.isArray(edit.cells)) {
@@ -2148,7 +2148,7 @@ export class RedlineEngine {
 
       // Structural table edits: verify the anchor really is a table row, and
       // that insert_row does not provide more cells than the row has columns —
-      // extra cells used to produce a structurally inconsistent row (QA M3).
+      // extra cells must never produce a structurally inconsistent row (QA M3).
       if (
         (edit.type === "insert_row" || edit.type === "delete_row") &&
         matches.length > 0
@@ -2331,16 +2331,14 @@ export class RedlineEngine {
         !["accept", "reject", "reply"].includes(c.type),
     );
 
-    // NOTE: a previous "edits_for_merge" pre-pass here silently UNWRAPPED a
-    // foreign author's <w:ins> when a strict/first edit only partially straddled
-    // its boundary — turning that author's tracked-inserted text into untracked
-    // committed body text before the edit applied, destroying their provenance.
-    // That is the same provenance-laundering failure mode the canonical engine
-    // refuses, so it has been removed: a partial straddle now surfaces the
-    // standard validation error ("Modification targets an active insertion from
-    // another author …") via validate_edits, matching the Python engine. An edit
-    // fully CONTAINED inside a foreign <w:ins> stays allowed and is handled by
-    // nesting the <w:del> inside that <w:ins> (see _apply_single_edit_indexed /
+    // Never pre-unwrap a foreign author's <w:ins> to make a partially
+    // straddling edit fit: that turns their tracked-inserted text into
+    // untracked committed body text before the edit applies, destroying
+    // their provenance. A partial straddle surfaces the standard validation
+    // error ("Modification targets an active insertion from another author
+    // …") via validate_edits, matching the Python engine. An edit fully
+    // CONTAINED inside a foreign <w:ins> is allowed and handled by nesting
+    // the <w:del> inside that <w:ins> (see _apply_single_edit_indexed /
     // _insert_and_split_ins).
 
     // BUG-7: Unified single-pass validation in wet-run / standard mode.
@@ -2729,8 +2727,8 @@ export class RedlineEngine {
 
     // Snapshot preview context now, while every resolved offset still refers
     // to the untouched document. The sweep below mutates the DOM and rebuilds
-    // the map, which shifts offsets and injects tracked-change markup —
-    // slicing full_text at report time garbled previews (QA H1).
+    // the map, shifting offsets and injecting tracked-change markup —
+    // slicing full_text at report time garbles previews (QA H1).
     for (const [res_edit] of resolved_edits) {
       this._capture_preview_context(res_edit);
       if (res_edit._parent_edit_ref) {

--- a/node/packages/core/src/sanitize/transforms.ts
+++ b/node/packages/core/src/sanitize/transforms.ts
@@ -427,8 +427,8 @@ export function scrub_doc_properties(doc: DocumentObject): string[] {
     const modifiers = findDescendantsByLocalName(corePart._element, 'lastModifiedBy');
     modifiers.forEach(c => { if (c.textContent) { lines.push(`Last modified by: ${c.textContent}`); c.textContent = ""; }});
 
-    // Title is often intentional, but can leak. Report it, don't strip —
-    // it previously did neither (QA 2026-07-17 F4; mirrors Python).
+    // Title is often intentional, but can leak. Report it, don't strip
+    // (QA 2026-07-17 F4; mirrors Python).
     const titles = findDescendantsByLocalName(corePart._element, 'title');
     titles.forEach(c => { if (c.textContent) { lines.push(`Title kept (review manually): "${c.textContent}"`); }});
 

--- a/node/packages/mcp-server/src/response-builders.ts
+++ b/node/packages/mcp-server/src/response-builders.ts
@@ -134,7 +134,7 @@ export function build_outline_response(
   outline_verbose: boolean = false,
   paragraph_offsets: Map<any, [number, number]> | null = null,
 ): ToolResult {
-  // Levels outside 1-6 are meaningless (0/negative used to render a
+  // Levels outside 1-6 are meaningless (0/negative would render a
   // nonsensical "L1-L0" range label, QA L2). Clamp to the nearest sensible
   // depth, mirroring the Python builder.
   outline_max_level = Math.max(1, Math.min(outline_max_level, 6));

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -131,8 +131,8 @@ def _print_sandbox_warning_and_exit(path: Path, exit_code: int = 1):
 def _require_input_file(path: Path, exit_code: int = 1) -> None:
     """
     Validates that an input path exists AND is a regular file. A directory
-    satisfies `.exists()`, so without the `.is_file()` check `open(dir, 'rb')`
-    escaped as a raw IsADirectoryError traceback (QA 2026-07-17 F7).
+    satisfies `.exists()`, so `.is_file()` is what turns `open(dir, 'rb')`'s
+    raw IsADirectoryError into a clean CLI error (QA 2026-07-17 F7).
     """
     if not path.exists():
         _print_sandbox_warning_and_exit(path, exit_code)
@@ -254,7 +254,7 @@ def _load_roundtrip_text(path: Path, original: Path, command: str) -> str:
     extract chrome and refusing inputs that cannot round-trip safely:
 
       - a single page of a multi-page extract (everything absent would be
-        diffed as deleted — QA 2026-07-17 F1 destroyed 80% of the document)
+        diffed as deleted — QA 2026-07-17 F1)
       - markup-view text containing CriticMarkup tokens (apply/diff compare
         against the CLEAN view, so the tokens — including reviewer names and
         change IDs — would be written into the document as literal prose,
@@ -411,10 +411,9 @@ def _load_batch_from_json(path: Path) -> List[DocumentChange]:
     """
     Loads a batch of changes from a JSON file in the unified
     List[DocumentChange] format — the same shape the MCP `changes` parameter
-    takes. This is the ONLY supported shape: the pre-v1.1.0
-    {"actions": [...], "edits": [...]} dict format was removed (its tolerant
-    action coercion silently inverted reject into accept, QA 2026-07-17 F2);
-    files in that shape get a targeted migration error instead of a guess.
+    takes. A dict root carrying 'actions'/'edits' keys is the pre-v1.1.0
+    batch shape; it gets a targeted migration error rather than a guess
+    (QA 2026-07-17 F2).
     """
     try:
         data = json.loads(_read_text_file(path))
@@ -507,9 +506,8 @@ def handle_extract(args):
         # errors) inside build_search_response. In full mode, 'all' returns
         # the entire document without page chrome — the round-trip artifact
         # for text-based apply/diff (QA 2026-07-17 F1). For the remaining
-        # modes it must be a positive integer — anything else used to fall
-        # through silently to page 1 (QA L1: `--page -1` / `--page abc`
-        # returned page 1).
+        # modes it must be a positive integer; anything else is a hard error,
+        # never a silent fallback to page 1 (QA L1).
         page_num = 1
         want_all_pages = False
         if args.page is not None and not getattr(args, "search_query", None):

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -409,45 +409,25 @@ def _format_batch_validation_error(exc: "ValidationError") -> str:
 
 def _load_batch_from_json(path: Path) -> List[DocumentChange]:
     """
-    Loads a batch of actions and edits from a JSON file.
-    Supports the unified List[DocumentChange] format or the legacy dict format.
+    Loads a batch of changes from a JSON file in the unified
+    List[DocumentChange] format — the same shape the MCP `changes` parameter
+    takes. This is the ONLY supported shape: the pre-v1.1.0
+    {"actions": [...], "edits": [...]} dict format was removed (its tolerant
+    action coercion silently inverted reject into accept, QA 2026-07-17 F2);
+    files in that shape get a targeted migration error instead of a guess.
     """
     try:
         data = json.loads(_read_text_file(path))
 
-        # Legacy dict format support
-        if isinstance(data, dict):
-            changes_data = []
-            for idx, item in enumerate(data.get("actions", [])):
-                raw_action = item.pop("action", None)
-                # Whitespace/case variants of valid values are normalized;
-                # anything else is a hard error. Never default to a value —
-                # least of all "accept", the destructive opposite of "reject"
-                # (QA 2026-07-17 F2: ' reject ' was silently applied as accept).
-                action_val = raw_action.strip().lower() if isinstance(raw_action, str) else None
-                if action_val not in ("accept", "reject", "reply"):
-                    if raw_action is None:
-                        raise ValueError(
-                            f"actions[{idx}] is missing the required 'action' field. "
-                            "Valid values: 'accept', 'reject', 'reply'."
-                        )
-                    raise ValueError(
-                        f"actions[{idx}] has an unrecognized 'action' value: {raw_action!r}. "
-                        "Valid values: 'accept', 'reject', 'reply'. "
-                        "Refusing to guess — a wrong default could apply the opposite of what you asked."
-                    )
-                item["type"] = action_val
-                changes_data.append(item)
-            for item in data.get("edits", []):
-                item["type"] = "modify"
-                if "original" in item:
-                    item["target_text"] = item.pop("original")
-                if "replace" in item:
-                    item["new_text"] = item.pop("replace")
-                changes_data.append(item)
-            data = changes_data
-        elif not isinstance(data, list):
-            raise ValueError("JSON root must be a list of changes or a legacy dict with 'actions' and 'edits'.")
+        if isinstance(data, dict) and ("actions" in data or "edits" in data):
+            raise ValueError(
+                'this file uses the removed pre-v1.1.0 {"actions": [...], "edits": [...]} format. '
+                "Provide a flat JSON list of typed changes instead — rename 'action' to 'type', "
+                "'original' to 'target_text', 'replace' to 'new_text', and merge both arrays "
+                "into one list.\n\n" + _CHANGE_TYPE_REFERENCE
+            )
+        if not isinstance(data, list):
+            raise ValueError("JSON root must be a list of change objects.\n\n" + _CHANGE_TYPE_REFERENCE)
 
         # BatchChanges (not the bare list) so the CLI tolerates the same LLM
         # quirks the MCP server does: stringified items, inferable missing

--- a/python/src/adeu/diff.py
+++ b/python/src/adeu/diff.py
@@ -199,18 +199,14 @@ def trim_common_context(target: str, new_val: str) -> tuple[int, int]:
             prefix_len += mlen
             suffix_len += mlen
 
-    # NOTE: An earlier version of this function suppressed suffix trimming when
-    # the trimmed new_text contained newlines, on the theory that the engine
-    # needed the full suffix kept in target_text so it could "transplant" it
-    # into the new paragraph structure. That theory was wrong: the engine never
-    # implemented such a transplant, and the suppression made multi-paragraph
-    # structured replacements (where target_text spans a paragraph break)
-    # produce orphan fragments and standalone reinsertions of the surviving
-    # suffix. See debug_bug1.py and the Bug 1 investigation.
-    #
-    # With suffix trimming enabled, the engine sees a clean
-    # (target='', new=insertion) pure-insertion edit at the paragraph boundary,
-    # which it handles correctly via the existing INSERTION path
+    # Suffix trimming stays active even when the trimmed new_text contains
+    # newlines. The engine implements no suffix "transplant" into new
+    # paragraph structure: keeping the full suffix inside target_text makes
+    # multi-paragraph structured replacements (where target_text spans a
+    # paragraph break) produce orphan fragments and standalone reinsertions
+    # of the surviving suffix. With the suffix trimmed, the engine sees a
+    # clean (target='', new=insertion) pure-insertion edit at the paragraph
+    # boundary and handles it via the INSERTION path
     # (get_insertion_anchor + track_insert).
 
     return prefix_len, suffix_len
@@ -282,17 +278,15 @@ def generate_edits_from_text(original_text: str, modified_text: str) -> List[Mod
                 # text. This matches the contract used by every other producer of
                 # _match_start_index in the codebase.
                 #
-                # We no longer use the "anchor baked into target_text" convention,
-                # because it produced contradictory edit objects: target_text would
-                # claim to live at [anchor_start : current_original_index] while
-                # _match_start_index pointed at current_original_index. The engine's
-                # apply_edits trusts _match_start_index when set, leading to silent
-                # document corruption (see debug_bug6_engine_baseline.py Case 1).
+                # Never bake an anchor into target_text instead: that yields a
+                # contradictory edit object — a target_text claiming to live at
+                # [anchor_start : current_original_index] while _match_start_index
+                # points at current_original_index — and apply_edits trusts
+                # _match_start_index when set, silently corrupting the document.
                 #
-                # The start-of-document special case is no longer needed: the engine
-                # handles _match_start_index=0 with target_text="" via
-                # get_insertion_anchor, which correctly anchors to the first run of
-                # the first paragraph.
+                # _match_start_index=0 with target_text="" needs no special case:
+                # get_insertion_anchor anchors it to the first run of the first
+                # paragraph.
                 edit = ModifyText(
                     type="modify",
                     target_text="",
@@ -314,17 +308,12 @@ def generate_edits_from_text(original_text: str, modified_text: str) -> List[Mod
         edit._match_start_index = idx
         edits.append(edit)
 
-    # Post-coalescing pass removed (was Pathology C in Bug 6 investigation).
-    # The pass mutated target_text/new_text by appending "gap + edit.target_text",
-    # which produced semantically meaningless edit objects when one or both of the
-    # adjacent edits was a pure insertion (whose target_text used to contain an
-    # anchor that overlapped with the gap). The result was duplicated text in
-    # both the rendered diff (Bug 6 visible symptom) and in the engine's output
-    # (silent document corruption — see debug_bug6_engine_baseline.py Case 6).
-    #
-    # If grouped/merged-hunk rendering is desired in the future, do it in
-    # _create_diff_output by visually grouping adjacent edits in the output,
-    # without mutating the underlying ModifyText objects.
+    # Adjacent hunks are deliberately NOT coalesced here. Bridging the gap by
+    # appending "gap + edit.target_text" yields semantically meaningless edit
+    # objects whenever an adjacent edit is a pure insertion — duplicated text
+    # in the rendered diff and silent corruption in the engine's output.
+    # Grouped/merged-hunk presentation belongs in the rendering layer, never
+    # in these ModifyText objects.
     return edits
 
 

--- a/python/src/adeu/domain.py
+++ b/python/src/adeu/domain.py
@@ -67,8 +67,7 @@ def extract_definitions_and_diagnostics(doc, base_text: str) -> Tuple[Dict[str, 
         # Drop unused terms from the SYMBOL TABLE only — that filter is noise
         # reduction for the Defined Terms listing, and must not gate the
         # Semantic Diagnostics: a term defined twice and never used is two
-        # drafting errors, not zero (QA 2026-07-17 F6 — the duplicate error
-        # was discarded together with the pruned term). Surface the orphan
+        # drafting errors, not zero (QA 2026-07-17 F6). Surface the orphan
         # definition itself as a diagnostic instead.
         for term in list(definitions.keys()):
             if definitions[term]["count"] == 0:

--- a/python/src/adeu/ingest.py
+++ b/python/src/adeu/ingest.py
@@ -64,23 +64,22 @@ def _extract_text_from_doc(
         clean_view: if True, simulate "Accept All Changes" view.
         include_appendix: if True (default), append the structural appendix
             (defined terms, anchors, diagnostics) to the projected text.
-            Set False when the caller knows it will discard the appendix
-            (e.g. mode='full' / mode='outline' since Step 3 — those modes
-            no longer ship the appendix in the response).
+            Set False when the caller discards the appendix (mode='full' /
+            mode='outline' do not ship it in the response).
         return_paragraph_offsets: if True (default False), returns a tuple
             (text, offset_map) where offset_map is Dict[id(p._element), (start, length)]
-            for every paragraph projected. Used by mode='outline' (Step 4 / Option A)
+            for every paragraph projected. Used by mode='outline'
             to avoid re-projecting paragraphs to extract heading text.
 
     Returns:
         - text: str   (default)
         - (text, offset_map): tuple   (when return_paragraph_offsets=True)
 
-    PERF: We no longer call normalize_docx() here. The ingest pipeline tolerates
-    fragmented runs (build_paragraph_text coalesces marker/wrapper boundaries
-    via FIX C logic). normalize_docx remains called by the RedlineEngine on
-    edit paths via the engine's own initialization, where DOM mutation is
-    already happening anyway. Read-only ingest skipping it is safe.
+    PERF: normalize_docx() is deliberately not called here. The ingest
+    pipeline tolerates fragmented runs (build_paragraph_text coalesces
+    marker/wrapper boundaries), and read-only ingest is safe without it;
+    the RedlineEngine normalizes on edit paths, where DOM mutation is
+    already happening anyway.
     """
     comments_mgr = CommentsManager(doc)
     comments_map = comments_mgr.extract_comments_data()

--- a/python/src/adeu/markup.py
+++ b/python/src/adeu/markup.py
@@ -533,9 +533,8 @@ def apply_edits_to_markdown(
             target_text=isolated_target,
             new_text=isolated_new,
             comment=edit.comment,
-            # 1-based, matching apply's "Edit N" reports and batch validation
-            # errors — a 0-based [Edit:N] here mis-mapped every cross-reference
-            # between a markup preview and an apply report by one (QA F10).
+            # 1-based, matching apply's "Edit N" reports and batch
+            # validation errors (QA 2026-07-17 F10).
             edit_index=orig_idx + 1,
             include_index=include_index,
             highlight_only=highlight_only,

--- a/python/src/adeu/mcp_components/_response_builders.py
+++ b/python/src/adeu/mcp_components/_response_builders.py
@@ -33,17 +33,15 @@ each channel is self-sufficient for its audience:
     position in the document without consulting structured_content.
 
   - `structured_content`: contains only fields the markdown UI widget actually
-    reads — `markdown`, `title`, `file_path`. Everything else has been removed
-    because nothing consumes it.
+    reads — `markdown`, `title`, `file_path`. Nothing else is consumed.
 
-APPENDIX SEPARATION (Step 2)
-----------------------------
+APPENDIX SEPARATION
+-------------------
 The Structural Appendix (defined terms, anchors, diagnostics) is NOT included
-in body pages. It is fetched on demand via mode='appendix'. Body pages get a
-small one-line footer pointing the agent at the appendix mode. This was
-necessary because on large legal documents the appendix can exceed 400KB,
-which (a) blew the per-page payload ceiling and (b) was being silently
-chunked by the MCP client.
+in body pages. It is fetched on demand via mode='appendix', and body pages get
+a small one-line footer pointing the agent at the appendix mode. Rationale: on
+large legal documents the appendix can exceed 400KB, which (a) blows the
+per-page payload ceiling and (b) gets silently chunked by the MCP client.
 
 The appendix is paginated using the same paginator as the body, with the
 appendix text passed AS the body input.
@@ -132,9 +130,8 @@ def build_full_document_response(text: str, file_path: str) -> ToolResult:
 
     This is the round-trip artifact for text-based apply/diff: page chrome is
     presentation, and a single page of a multi-page document can never round-
-    trip safely (QA 2026-07-17 F1 — there was previously no supported way to
-    extract a >19k-char document completely). Reached via `--page all` on the
-    CLI and `page='all'` with `mode='full'` over MCP.
+    trip safely (QA 2026-07-17 F1). Reached via `--page all` on the CLI and
+    `page='all'` with `mode='full'` over MCP.
     """
     body, _appendix = split_structural_appendix(text)
     ui_markdown = body
@@ -153,9 +150,9 @@ def build_paginated_response(text: str, page: int, file_path: str, is_cli: bool 
     """
     Splits projected Markdown into pages and returns the requested page.
 
-    The structural appendix is NOT included in the page content (since Step 2).
-    Body pages get a one-line footer pointing the agent at mode='appendix'
-    if the document has an appendix.
+    The structural appendix is NOT included in the page content. Body pages
+    get a one-line footer pointing the agent at mode='appendix' if the
+    document has an appendix.
 
     Raises ToolError if `page` is out of range.
     """
@@ -210,14 +207,14 @@ def build_outline_response(
             _extract_text_from_doc(return_paragraph_offsets=True).
     """
 
-    # Levels outside 1-6 are meaningless (0/negative used to render a
+    # Levels outside 1-6 are meaningless (0/negative would render a
     # nonsensical "L1-L0" range label, QA L2). The CLI rejects them at parse
     # time; clamp here so MCP callers get the nearest sensible depth.
     outline_max_level = max(1, min(outline_max_level, 6))
 
     # Pagination is used here only to compute body page boundaries for
     # heading->page mapping. We deliberately pass empty string instead of the
-    # appendix because per-page appendix injection is gone (Step 2).
+    # appendix — the appendix is never injected per page.
     body, _appendix = split_structural_appendix(projected_text)
     pagination_result = paginate(body, structural_appendix="")
 

--- a/python/src/adeu/mcp_components/tools/document.py
+++ b/python/src/adeu/mcp_components/tools/document.py
@@ -166,7 +166,7 @@ async def _read_docx_disk(
         # build_structural_appendix() cost (~8.5s on a 1000-page doc).
         needs_appendix = mode == "appendix"
         # mode='outline' uses paragraph offsets to avoid re-projecting each
-        # paragraph (Step 4 / Option A).
+        # paragraph.
         needs_offsets = mode == "outline"
 
         extract_result = _extract_text_from_doc(
@@ -189,8 +189,8 @@ async def _read_docx_disk(
 
         # In full mode, page='all' returns the entire document without page
         # chrome — the round-trip artifact for text-based apply/diff
-        # (QA 2026-07-17 F1; mirrors the CLI's --page all). It used to fall
-        # through the isdigit() check below and silently render page 1.
+        # (QA 2026-07-17 F1; mirrors the CLI's --page all). Dispatched before
+        # the isdigit() check below, which would silently render page 1.
         if mode == "full" and page is not None and str(page).strip().lower() == "all":
             return build_full_document_response(text, file_path)
 

--- a/python/src/adeu/mcp_components/tools/live_word.py
+++ b/python/src/adeu/mcp_components/tools/live_word.py
@@ -345,7 +345,7 @@ if sys.platform == "win32":
             # in the response. Skip building it for the other modes (~8.5s saved on
             # large docs).
             needs_appendix = mode == "appendix"
-            # Step 4 / Option A: outline mode uses paragraph offsets to avoid
+            # Outline mode uses paragraph offsets to avoid
             # re-projecting each paragraph.
             needs_offsets = mode == "outline"
 

--- a/python/src/adeu/outline.py
+++ b/python/src/adeu/outline.py
@@ -108,7 +108,7 @@ def extract_outline(
         body_pages: pre-appendix-injection page bodies, in order.
         body_page_offsets: start offset (in projected_body) of each entry in body_pages.
             Must satisfy len(body_pages) == len(body_page_offsets).
-        paragraph_offsets: when provided (Step 4 / Option A), this is the offset
+        paragraph_offsets: when provided, this is the offset
             map produced by _extract_text_from_doc(return_paragraph_offsets=True).
             Used to fast-path heading text extraction by slicing projected_body
             instead of re-projecting each paragraph. When None, falls back to the
@@ -436,11 +436,10 @@ def _walk_doc_body(doc: DocumentObject, comments_map: dict) -> List[_BlockRecord
     # we need length for. For outline purposes, the only thing that matters is
     # heading position; non-heading lengths only matter as cumulative offsets.
     #
-    # Tradeoff: we still call build_paragraph_text per paragraph here. That's
-    # O(N) over body paragraphs, same complexity as before, but the per-call
-    # cost is unchanged. The win comes from removing the recursive table
-    # measuring (which previously called extract_table AND walked cells AND
-    # called build_paragraph_text per inner paragraph).
+    # Tradeoff: build_paragraph_text still runs once per body paragraph —
+    # O(N) — but tables are measured by length arithmetic alone. Recursively
+    # measuring them (extract_table + walking cells + build_paragraph_text
+    # per inner paragraph) is the expensive path this avoids.
     records: List[_BlockRecord] = []
     cursor = body_start_offset
     is_first_block = True

--- a/python/src/adeu/redline/comments.py
+++ b/python/src/adeu/redline/comments.py
@@ -336,9 +336,9 @@ class CommentsManager:
         Read paths must use this guard instead of testing the raw backing field
         `self._comments_part`: on a fresh manager the backing field is None
         until the lazy `comments_part` property populates it, so guarding on
-        the field silently no-ops even though the document HAS comments — that
-        is exactly how `sanitize` shipped reporting comments removed while
-        word/comments.xml survived intact (QA 2026-07-17 F3). Checking the
+        the field silently no-ops even though the document HAS comments, and
+        sanitize then reports comments removed while word/comments.xml
+        survives intact (QA 2026-07-17 F3). Checking the
         package (rather than unconditionally touching the property) keeps the
         other guarantee: a document with no comments part never has one
         created as a side effect of a read/delete.

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -385,8 +385,8 @@ class RedlineEngine:
         Snapshots the document text around a resolved edit BEFORE anything is
         applied. Previews rendered after the batch mutates the DOM cannot slice
         full_text at the stored offsets: applied edits shift offsets and inject
-        tracked-change markup, which produced garbled previews mixing unrelated
-        edits and internal scaffolding (QA H1).
+        tracked-change markup, garbling previews with unrelated edits and
+        internal scaffolding (QA H1).
         """
         if not isinstance(edit, ModifyText):
             return
@@ -1477,8 +1477,8 @@ class RedlineEngine:
                 if live_matches:
                     matches = live_matches
 
-            # Since the structural appendix is no longer in the mapper,
-            # all matches are valid document body matches.
+            # The structural appendix is not part of the mapper's
+            # projection, so all matches are valid document body matches.
             valid_matches = matches
 
             if len(valid_matches) == 0:
@@ -1625,7 +1625,7 @@ class RedlineEngine:
 
             # Structural table edits: verify the anchor really is a table row,
             # and that insert_row does not provide more cells than the row has
-            # columns — extra cells used to be silently discarded (QA M3).
+            # columns — extra cells must never be silently discarded (QA M3).
             if isinstance(edit, (InsertTableRow, DeleteTableRow)) and valid_matches:
                 start, length = valid_matches[0]
                 n_cols = self._column_count_at(target_mapper, start, length)
@@ -1688,8 +1688,8 @@ class RedlineEngine:
     def _report_new_text(edit: Any) -> str:
         """
         The "new text" a batch report should show for an edit. InsertTableRow
-        has no new_text field — surface its cell contents instead of the
-        misleading empty string the report used to print (QA M4).
+        has no new_text field — surface its cell contents rather than a
+        misleading empty string (QA M4).
         """
         if isinstance(edit, InsertTableRow):
             return " | ".join(edit.cells)
@@ -1817,7 +1817,7 @@ class RedlineEngine:
             # Caller-pinned edits resolve by position, so the document-context
             # checks (not-found / ambiguity) don't apply to them — but the
             # string-shape checks do, exactly as the validate_edits docstring
-            # promises. Without this, the text-diff path wrote raw CriticMarkup
+            # promises. Without this, the text-diff path writes raw CriticMarkup
             # (including reviewer names and change IDs) into document bodies as
             # prose (QA 2026-07-17 F8).
             pinned_ok: List[Tuple[int, Any]] = []
@@ -2026,8 +2026,8 @@ class RedlineEngine:
 
         # Snapshot preview context now, while every resolved offset still refers
         # to the untouched document. The sweep below mutates the DOM and rebuilds
-        # the map, which shifts offsets and injects tracked-change markup —
-        # slicing full_text at report time garbled previews (QA H1).
+        # the map, shifting offsets and injecting tracked-change markup —
+        # slicing full_text at report time garbles previews (QA H1).
         for res_edit, _ in resolved_edits:
             self._capture_preview_context(res_edit)
             parent = getattr(res_edit, "_parent_edit_ref", None)
@@ -2765,17 +2765,15 @@ class RedlineEngine:
         if op == EditOperationType.PARAGRAPH_REPLACE:
             return self._apply_paragraph_replace(edit)
 
-        # Allocate logical-edit IDs up front. A single ModifyText that spans
-        # multiple XML runs (e.g. a target containing a bold word, which OOXML
-        # stores as a separate <w:r> element) or whose new_text spans multiple
-        # paragraphs used to mint a fresh w:id per <w:ins>/<w:del> element,
-        # surfacing as N [Chg:N] entries in the projected bubble even though
-        # Word renders the change as a single review entry. We now allocate one
-        # id for the delete side and one for the insert side per logical
-        # operation, and reuse them across every <w:ins>/<w:del> element this
-        # edit produces. The mapper's _build_merged_meta_block already
-        # deduplicates repeated IDs via seen_sigs, so this collapses the bubble
-        # automatically without any projection-side change to the engine.
+        # Allocate logical-edit IDs up front: one id for the delete side and
+        # one for the insert side per logical operation, reused across every
+        # <w:ins>/<w:del> element this edit produces. A single ModifyText can
+        # span multiple XML runs (e.g. a target containing a bold word, which
+        # OOXML stores as a separate <w:r> element) or multiple paragraphs;
+        # minting a fresh w:id per element would surface N [Chg:N] entries in
+        # the projected bubble for what Word renders as a single review entry.
+        # The mapper's _build_merged_meta_block deduplicates repeated IDs via
+        # seen_sigs, collapsing the bubble without any projection-side change.
         del_id: Optional[str] = None
         ins_id: Optional[str] = None
         if op in (EditOperationType.DELETION, EditOperationType.MODIFICATION):

--- a/python/src/adeu/redline/mapper.py
+++ b/python/src/adeu/redline/mapper.py
@@ -200,8 +200,8 @@ class DocumentMapper:
             self._text_chunks.pop()
 
         self.full_text = "".join(self._text_chunks)
-        # We no longer calculate the appendix for the mapping engine.
-        # It's an unnecessary O(N) calculation that isn't needed for redlining.
+        # The appendix is not part of the mapping engine's projection —
+        # an O(N) calculation redlining never needs.
         self.appendix_start_index = -1
 
     def _map_blocks(self, container, offset: int) -> int:

--- a/python/src/adeu/sanitize/transforms.py
+++ b/python/src/adeu/sanitize/transforms.py
@@ -330,11 +330,9 @@ def remove_all_comments(doc: DocumentObject) -> list[str]:
             if el.getparent() is not None:
                 el.getparent().remove(el)
 
-    # Verify the assertion before reporting it. The report lines above are
+    # Verify the assertion before reporting it: the report lines above are
     # built from a PRE-deletion snapshot, so they are structurally incapable
-    # of noticing a failed deletion — which is how a delete_comment no-op
-    # shipped a report reading "Comments removed: N" while word/comments.xml
-    # still carried every comment (QA 2026-07-17 F3). A fresh manager reads
+    # of noticing a failed deletion (QA 2026-07-17 F3). A fresh manager reads
     # actual package state.
     remaining = CommentsManager(doc).extract_comments_data()
     if remaining:
@@ -464,9 +462,8 @@ def scrub_doc_properties(doc: DocumentObject) -> list[str]:
         lines.append(f"Last modified by: {core.last_modified_by}")
         core.last_modified_by = ""
     if core.title:
-        # Title is often intentional, but can leak. Report it, don't strip —
-        # and actually DO report it: the 1.21.0 build had a bare `pass` here,
-        # so codename titles left the building unreported (QA 2026-07-17 F4).
+        # Title is often intentional, but can leak. Report it, don't strip
+        # (QA 2026-07-17 F4).
         lines.append(f'Title kept (review manually): "{core.title}"')
     # Classification-style properties are textbook leak vectors ("Project
     # Falcon", "confidential,merger,..."). Unlike title they carry no

--- a/python/tests/test_repro_qa_report_v5.py
+++ b/python/tests/test_repro_qa_report_v5.py
@@ -6,7 +6,9 @@ Finding index (severity as reported):
   F1  🔴 paginated extract → full-document apply/diff silently deletes
       everything past page 1 and writes page chrome into the document
   F2  🟠 legacy {"actions": [...]} batch coerces unrecognized action values
-      (" reject ", "rejcet", missing) to "accept" — semantic inversion
+      (" reject ", "rejcet", missing) to "accept" — semantic inversion.
+      Resolution superseded: the entire undocumented pre-v1.1.0 dict format
+      was removed; that shape now gets a targeted migration error.
   F3  🟠 sanitize reports comments removed while word/comments.xml survives
       (delete_comment guards on the backing field, not the lazy property)
   F4  🟠 dc:title / cp:category / cp:keywords / dc:subject / contentStatus
@@ -311,49 +313,72 @@ class TestF1PaginationRoundTrip:
 # ---------------------------------------------------------------------------
 
 
-class TestF2LegacyActionCoercion:
-    def _apply_legacy(self, tmp_path, capsys, actions) -> tuple[int, str, Path]:
+class TestF2LegacyFormatRemoved:
+    """The pre-v1.1.0 {"actions": [...], "edits": [...]} dict format — F2's
+    entire attack surface — is removed. Any file in that shape must be
+    rejected with a targeted migration error before a single change is
+    interpreted, regardless of its content."""
+
+    def _apply_batch(self, tmp_path, capsys, payload) -> tuple[int, str, Path]:
         docx_path = tmp_path / "tracked.docx"
-        docx_path.write_bytes(_make_doc_with_fee_change().getvalue())
+        input_bytes = _make_doc_with_fee_change().getvalue()
+        docx_path.write_bytes(input_bytes)
         json_path = tmp_path / "a.json"
-        json_path.write_text(json.dumps({"actions": actions}), encoding="utf-8")
+        json_path.write_text(json.dumps(payload), encoding="utf-8")
         out_path = tmp_path / "out.docx"
         rc = _run_cli(["apply", str(docx_path), str(json_path), "-o", str(out_path)])
         err = capsys.readouterr().err
+        # Whatever the outcome, apply must never mutate its input file.
+        assert docx_path.read_bytes() == input_bytes
         return rc, err, out_path
 
-    def test_whitespace_padded_reject_is_normalized_not_inverted(self, tmp_path, capsys):
-        rc, _err, out_path = self._apply_legacy(
+    @pytest.mark.parametrize(
+        "actions",
+        [
+            [{"action": "reject", "target_id": "Chg:101"}],  # even well-formed legacy input
+            [{"action": " reject ", "target_id": "Chg:101"}],  # F2's original repro
+            [{"action": "rejcet", "target_id": "Chg:101"}],
+            [{"target_id": "Chg:101"}],
+            [{"action": None, "target_id": "Chg:101"}],
+        ],
+    )
+    def test_legacy_actions_format_is_rejected_with_migration_guidance(self, tmp_path, capsys, actions):
+        rc, err, out_path = self._apply_batch(tmp_path, capsys, {"actions": actions})
+        assert rc != 0, "the removed legacy format was silently interpreted"
+        assert not out_path.exists()
+        # Actionable migration error: names the removed shape and the modern one.
+        assert "removed" in err
+        assert "'action' to 'type'" in err
+        assert "AttributeError" not in err
+
+    def test_legacy_edits_bucket_is_rejected(self, tmp_path, capsys):
+        rc, err, out_path = self._apply_batch(
+            tmp_path, capsys, {"edits": [{"original": "$12,500", "replace": "$99,999"}]}
+        )
+        assert rc != 0
+        assert not out_path.exists()
+        assert "'original' to 'target_text'" in err
+
+    def test_non_legacy_dict_root_gets_generic_list_error(self, tmp_path, capsys):
+        rc, err, out_path = self._apply_batch(tmp_path, capsys, {"changes": []})
+        assert rc != 0
+        assert not out_path.exists()
+        assert "list of change objects" in err
+
+    def test_migrated_modern_equivalent_applies(self, tmp_path, capsys):
+        """The migration the error message describes must actually work."""
+        rc, _err, out_path = self._apply_batch(
             tmp_path,
             capsys,
             [
-                {"action": " reject ", "target_id": "Chg:101"},
-                {"action": "reject\n", "target_id": "Chg:102"},
+                {"type": "reject", "target_id": "Chg:101"},
+                {"type": "reject", "target_id": "Chg:102"},
             ],
         )
         assert rc == 0
         result = _clean_text(out_path.read_bytes())
-        assert "$10,000" in result, "whitespace-padded 'reject' was silently applied as ACCEPT"
+        assert "$10,000" in result
         assert "$12,500" not in result
-
-    @pytest.mark.parametrize("bad_action", ["rejcet", "PLEASE_DO_NOT_ACCEPT", ""])
-    def test_unrecognized_action_is_a_hard_error(self, tmp_path, capsys, bad_action):
-        rc, err, out_path = self._apply_legacy(tmp_path, capsys, [{"action": bad_action, "target_id": "Chg:101"}])
-        assert rc != 0, f"unrecognized action {bad_action!r} was silently coerced to accept"
-        assert not out_path.exists()
-        assert "accept" in err and "reject" in err  # names the valid values
-
-    def test_missing_action_is_a_hard_error(self, tmp_path, capsys):
-        rc, err, out_path = self._apply_legacy(tmp_path, capsys, [{"target_id": "Chg:101"}])
-        assert rc != 0, "missing 'action' key was silently coerced to accept"
-        assert not out_path.exists()
-
-    @pytest.mark.parametrize("bad_action", [None, 42])
-    def test_non_string_action_produces_clean_error(self, tmp_path, capsys, bad_action):
-        rc, err, out_path = self._apply_legacy(tmp_path, capsys, [{"action": bad_action, "target_id": "Chg:101"}])
-        assert rc != 0
-        assert "AttributeError" not in err
-        assert "has no attribute" not in err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The {"actions": [...], "edits": [...]} dict shape accepted by 'adeu apply' and 'adeu markup' was never documented, nothing in the repo produces it, and its tolerant translation layer is where QA F2 (reject silently inverted to accept) lived. The unified typed-list format — identical to the MCP 'changes' schema — is now the only accepted shape.

Files in the old shape get a targeted migration error naming the field renames ('action' -> 'type', 'original' -> 'target_text', 'replace' -> 'new_text') plus the change-type reference, instead of a guess. The F2 regression tests are updated accordingly: every legacy payload — including well-formed ones — is rejected before any change is interpreted, the input file is never mutated, and the migrated modern equivalent of the F2 fixture applies correctly.


Claude-Session: https://claude.ai/code/session_01EPLjgC3CRjawkiGcTtFEUF

## Pull Request Overview

Please provide a brief description of the changes introduced by this PR.

---

## 🛑 Ecosystem / Vendor Integrations (READ FIRST)
*If you are submitting a new third-party integration, API connector, or LegalTech tool to the `ecosystem/` directory, you **must** complete this checklist. PRs that fail to meet these criteria will be automatically closed without review.*

- [ ] **Zero Core Coupling:** I confirm this PR does NOT modify `src/adeu/` or `node/packages/core/`. All execution logic is self-contained or strictly uses approved callback/middleware hooks.
- [ ] **Strict Dependency Isolation:** I have included a dedicated package manager file (`pyproject.toml` or `package.json`) exclusively within my `ecosystem/<plugin>/` directory. My dependencies do not pollute the root lockfiles.
- [ ] **No Hoisting / Phantom Dependencies:** I am using explicit workspace protocols (e.g., `workspace:*` or `adeu = { path = "../../python" }`) to reference the core engine.
- [ ] **Commercial Transparency:** If my integration requires a paid subscription, API key, or routes to a closed-source endpoint, it is explicitly declared at the very top of my `README.md`.
- [ ] **14-Day Maintenance SLA:** I have read and agree to the `VENDOR_POLICY.md`. I acknowledge that I am responsible for the perpetual OpEx of this code. If this integration breaks and I fail to resolve the issue within 14 days, I understand the integration will be aggressively pruned/deleted.

---

## 🛠️ Core Engine Contributions
*If you are contributing to the core Adeu OpenXML parsing engine or standard MCP tooling:*

- [ ] I have added a regression test (e.g., `tests/test_repro_issue_name.py`) to prove the bug is fixed or the feature handles Edge-Case OpenXML correctly.
- [ ] I have verified that changes to `RedlineEngine` do not cause silent DOM corruption (e.g., bypassing `w:ins`/`w:del` tags).
- [ ] I have run the formatting and linting suite (`uv run ruff format .` and `uv run mypy src`).
- [ ] (If applicable) I have tested this against Live MS Word via COM (`live_word.py`) to ensure parity between Disk and Live operations.

## Related Issues
Closes # (Issue Number)