### PR TITLE
fix: automated agentic fix for CLI bug

### DIFF
--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -2662,6 +2662,61 @@ class RedlineEngine:
 
         return True
 
+    def _is_row_fully_deleted(self, row_el, start_idx: int, length: int, active_mapper) -> bool:
+        # Find all active runs currently under row_el
+        active_runs = []
+        for r_el in row_el.findall(".//" + qn("w:r")):
+            parent = r_el.getparent()
+            is_deleted = False
+            while parent is not None and parent != row_el:
+                if parent.tag == qn("w:del"):
+                    is_deleted = True
+                    break
+                parent = parent.getparent()
+            if not is_deleted:
+                active_runs.append(r_el)
+
+        # If there are still active runs, the row is not fully deleted
+        if active_runs:
+            return False
+
+        # Since row_el was collected in seen_rows, we know it was targeted.
+        return True
+
+    def _mark_fully_deleted_rows_in_range(
+        self, del_elems, virtual_spans, start_idx: int, length: int, active_mapper, del_id: Optional[str]
+    ) -> None:
+        seen_rows = set()
+        for del_elem in del_elems:
+            curr = del_elem
+            row_el = None
+            while curr is not None:
+                if curr.tag == qn("w:tr"):
+                    row_el = curr
+                    break
+                curr = curr.getparent()
+            if row_el is not None and row_el not in seen_rows:
+                seen_rows.add(row_el)
+
+        for span in virtual_spans:
+            if span.paragraph:
+                curr = span.paragraph._element
+                row_el = None
+                while curr is not None:
+                    if curr.tag == qn("w:tr"):
+                        row_el = curr
+                        break
+                    curr = curr.getparent()
+                if row_el is not None and row_el not in seen_rows:
+                    seen_rows.add(row_el)
+
+        for row_el in seen_rows:
+            if self._is_row_fully_deleted(row_el, start_idx, length, active_mapper):
+                trPr = row_el.get_or_add_trPr()
+                if trPr.find(qn("w:del")) is None:
+                    del_el = self._create_track_change_tag("w:del", reuse_id=del_id)
+                    trPr.append(del_el)
+
     def _maybe_paragraph_replace(
         self,
         edit: ModifyText,
@@ -3523,11 +3578,16 @@ class RedlineEngine:
         if op == EditOperationType.DELETION:
             first_del_element = None
             last_del_element = None
+            del_elems = []
             for run in target_runs:
                 del_elem = self.track_delete_run(run, reuse_id=del_id)
+                if del_elem is not None:
+                    del_elems.append(del_elem)
                 if first_del_element is None:
                     first_del_element = del_elem
                 last_del_element = del_elem
+
+            self._mark_fully_deleted_rows_in_range(del_elems, virtual_spans, start_idx, length, active_mapper, del_id)
 
             if edit.comment and first_del_element is not None and last_del_element is not None:
                 # The deletions may be nested inside a foreign author's <w:ins>;
@@ -3556,11 +3616,16 @@ class RedlineEngine:
         elif op == EditOperationType.MODIFICATION:
             first_del_element = None
             last_del_element = None
+            del_elems = []
             for run in target_runs:
                 del_elem = self.track_delete_run(run, reuse_id=del_id)
+                if del_elem is not None:
+                    del_elems.append(del_elem)
                 if first_del_element is None:
                     first_del_element = del_elem
                 last_del_element = del_elem
+
+            self._mark_fully_deleted_rows_in_range(del_elems, virtual_spans, start_idx, length, active_mapper, del_id)
 
             if first_del_element is not None and last_del_element is not None and edit.new_text:
                 parent = last_del_element.getparent()

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -1,0 +1,83 @@
+# FILE: tests/test_cli_bug_repro.py
+"""
+Regression test for the adeu apply text-file verification failure on table/structural deletion.
+"""
+
+import sys
+from unittest.mock import patch
+
+from docx import Document
+
+
+def _run_cli(argv: list[str]) -> int:
+    """Runs the adeu CLI in-process; returns the exit code."""
+    from adeu.cli import main
+
+    with patch.object(sys, "argv", ["adeu"] + argv):
+        try:
+            main()
+        except SystemExit as e:
+            return int(e.code or 0)
+    return 0
+
+
+def test_apply_table_deletion_repro(tmp_path):
+    """
+    Test that adeu apply can successfully delete table/structural elements from a text file,
+    computes the textual differences, marks the table rows as deleted, and outputs a valid .docx file
+    without failing the post-apply verification check.
+    """
+    docx_path = tmp_path / "original.docx"
+    txt_path = tmp_path / "clean.txt"
+    edited_txt_path = tmp_path / "edited_clean.txt"
+    out_path = tmp_path / "applied.docx"
+
+    # 1. Create original.docx containing a heading and a standard 3x3 table
+    doc = Document()
+    doc.add_heading("My Document Heading", level=1)
+
+    table = doc.add_table(rows=3, cols=3)
+    table.cell(0, 0).text = "Header A"
+    table.cell(0, 1).text = "Header B"
+    table.cell(0, 2).text = "Header C"
+
+    for r in range(1, 3):
+        for c in range(3):
+            table.cell(r, c).text = f"Row{r} Col{c}"
+
+    doc.save(docx_path)
+
+    # 2. Extract clean text using the CLI
+    rc_extract = _run_cli(["extract", "--clean-view", str(docx_path), "-o", str(txt_path)])
+    assert rc_extract == 0, "CLI extract failed"
+    assert txt_path.exists(), "Clean text file was not created"
+
+    # 3. Read the clean text and delete the lines representing the table
+    clean_text = txt_path.read_text(encoding="utf-8")
+
+    # Filter out table lines (containing headers or row contents or structural pipes)
+    filtered_lines = []
+    for line in clean_text.splitlines():
+        if "|" in line or "Row" in line or "Header" in line:
+            continue
+        filtered_lines.append(line)
+
+    edited_clean_text = "\n".join(filtered_lines)
+    edited_txt_path.write_text(edited_clean_text, encoding="utf-8")
+
+    # 4. Apply back using the CLI with --allow-major-deletions
+    rc_apply = _run_cli([
+        "apply",
+        str(docx_path),
+        str(edited_txt_path),
+        "-o",
+        str(out_path),
+        "--allow-major-deletions"
+    ])
+
+    # This asserts the CORRECT expected behavior:
+    # Under the bug, apply fails (returns non-zero) and does not write out
+    # applied.docx because of verification mismatch.
+    # When fixed, it should succeed (return 0) and write out the file.
+    assert rc_apply == 0, "adeu apply failed with exit code 1 due to post-apply validation mismatch"
+    assert out_path.exists(), "Applied output docx was not written"

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -66,14 +66,7 @@ def test_apply_table_deletion_repro(tmp_path):
     edited_txt_path.write_text(edited_clean_text, encoding="utf-8")
 
     # 4. Apply back using the CLI with --allow-major-deletions
-    rc_apply = _run_cli([
-        "apply",
-        str(docx_path),
-        str(edited_txt_path),
-        "-o",
-        str(out_path),
-        "--allow-major-deletions"
-    ])
+    rc_apply = _run_cli(["apply", str(docx_path), str(edited_txt_path), "-o", str(out_path), "--allow-major-deletions"])
 
     # This asserts the CORRECT expected behavior:
     # Under the bug, apply fails (returns non-zero) and does not write out


### PR DESCRIPTION
## Pull Request Overview

Please provide a brief description of the changes introduced by this PR.

---

## 🛑 Ecosystem / Vendor Integrations (READ FIRST)
*If you are submitting a new third-party integration, API connector, or LegalTech tool to the `ecosystem/` directory, you **must** complete this checklist. PRs that fail to meet these criteria will be automatically closed without review.*

- [ ] **Zero Core Coupling:** I confirm this PR does NOT modify `src/adeu/` or `node/packages/core/`. All execution logic is self-contained or strictly uses approved callback/middleware hooks.
- [ ] **Strict Dependency Isolation:** I have included a dedicated package manager file (`pyproject.toml` or `package.json`) exclusively within my `ecosystem/<plugin>/` directory. My dependencies do not pollute the root lockfiles.
- [ ] **No Hoisting / Phantom Dependencies:** I am using explicit workspace protocols (e.g., `workspace:*` or `adeu = { path = "../../python" }`) to reference the core engine.
- [ ] **Commercial Transparency:** If my integration requires a paid subscription, API key, or routes to a closed-source endpoint, it is explicitly declared at the very top of my `README.md`.
- [ ] **14-Day Maintenance SLA:** I have read and agree to the `VENDOR_POLICY.md`. I acknowledge that I am responsible for the perpetual OpEx of this code. If this integration breaks and I fail to resolve the issue within 14 days, I understand the integration will be aggressively pruned/deleted.

---

## 🛠️ Core Engine Contributions
*If you are contributing to the core Adeu OpenXML parsing engine or standard MCP tooling:*

- [ ] I have added a regression test (e.g., `tests/test_repro_issue_name.py`) to prove the bug is fixed or the feature handles Edge-Case OpenXML correctly.
- [ ] I have verified that changes to `RedlineEngine` do not cause silent DOM corruption (e.g., bypassing `w:ins`/`w:del` tags).
- [ ] I have run the formatting and linting suite (`uv run ruff format .` and `uv run mypy src`).
- [ ] (If applicable) I have tested this against Live MS Word via COM (`live_word.py`) to ensure parity between Disk and Live operations.

## Related Issues
Closes # (Issue Number)