### PR TITLE
Fix strict sequential action ordering in edit batches

### DIFF
--- a/node/packages/core/src/engine.ts
+++ b/node/packages/core/src/engine.ts
@@ -3498,8 +3498,22 @@ export class RedlineEngine {
     let already_resolved = 0;
     const resolved_history = new Map<string, string>(); // id -> resolving action type
 
-    for (let pos = 0; pos < actions.length; pos++) {
-      const action = actions[pos];
+    // Sort actions internally: non-destructive metadata operations (ReplyComment) first,
+    // followed by destructive structural operations (AcceptChange, RejectChange).
+    // Stable sort preserves the original relative ordering, and we preserve `pos`
+    // so diagnostic messages refer to the original array indexes.
+    const sortedActions = actions
+      .map((action, pos) => ({ action, pos }))
+      .sort((a, b) => {
+        const aPri = a.action.type === "reply" ? 0 : 1;
+        const bPri = b.action.type === "reply" ? 0 : 1;
+        if (aPri !== bPri) {
+          return aPri - bPri;
+        }
+        return a.pos - b.pos;
+      });
+
+    for (const { action, pos } of sortedActions) {
       const type = action.type;
       if (type === "reply") {
         const cid = action.target_id.replace("Com:", "");

--- a/python/src/adeu/mcp_components/tools/live_word.py
+++ b/python/src/adeu/mcp_components/tools/live_word.py
@@ -607,7 +607,12 @@ if sys.platform == "win32":
                 mapper = DocumentMapper(py_doc)
                 _, _, mapping = _get_haystack()
 
-                for act in actions:
+                # Sort actions internally: non-destructive metadata operations (ReplyComment) first,
+                # followed by destructive structural operations (AcceptChange, RejectChange).
+                # Stable sort preserves the original relative ordering.
+                sorted_actions = sorted(actions, key=lambda x: 0 if isinstance(x, ReplyComment) else 1)
+
+                for act in sorted_actions:
                     try:
                         xml_id = act.target_id.split(":")[-1]
                         if isinstance(act, (AcceptChange, RejectChange)):

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -4003,7 +4003,13 @@ class RedlineEngine:
         already_resolved = 0
         resolved_history: dict = {}  # revision id -> action type that resolved it
 
-        for pos, act in enumerate(actions):
+        # Sort actions internally: non-destructive metadata operations (ReplyComment) first,
+        # followed by destructive structural operations (AcceptChange, RejectChange).
+        # Stable sort preserves the original relative ordering, and we preserve `pos`
+        # so diagnostic messages refer to the original array indexes.
+        sorted_actions = sorted(enumerate(actions), key=lambda x: 0 if isinstance(x[1], ReplyComment) else 1)
+
+        for pos, act in sorted_actions:
             raw_id = act.target_id
             target_id = raw_id
 

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -74,3 +74,74 @@ def test_apply_table_deletion_repro(tmp_path):
     # When fixed, it should succeed (return 0) and write out the file.
     assert rc_apply == 0, "adeu apply failed with exit code 1 due to post-apply validation mismatch"
     assert out_path.exists(), "Applied output docx was not written"
+
+
+def test_apply_comment_reply_order_repro(tmp_path):
+    """
+    Test that adeu apply successfully processes a batch of actions containing
+    both an AcceptChange on a tracked change and a ReplyComment on the wrapping comment,
+    even when the AcceptChange is ordered before the ReplyComment in the batch array.
+
+    The correct expected behavior is that both the AcceptChange and ReplyComment are
+    successfully applied. Under the bug, the accept is executed first, which deletes the
+    associated comment from the document structure, causing the reply to fail validation and
+    reverting/failing the entire batch application.
+    """
+    import io
+    import json
+    import re
+
+    from adeu.ingest import extract_text_from_stream
+    from adeu.models import ModifyText
+    from adeu.redline.engine import RedlineEngine
+
+    docx_path = tmp_path / "original.docx"
+    updated_docx_path = tmp_path / "updated.docx"
+    batch_json_path = tmp_path / "batch.json"
+    out_path = tmp_path / "applied.docx"
+
+    # 1. Create a baseline docx file
+    doc = Document()
+    doc.add_paragraph("Text with comment.")
+    doc.save(docx_path)
+
+    # 2. Add track change + comment to create a document with pending review actions
+    with open(docx_path, "rb") as f:
+        stream = io.BytesIO(f.read())
+
+    engine = RedlineEngine(stream, author="Author1")
+    edit = ModifyText(target_text="Text", new_text="TextModified", comment="Initial Comment")
+    engine.apply_edits([edit])
+
+    stream_mid = engine.save_to_stream()
+    with open(updated_docx_path, "wb") as f:
+        f.write(stream_mid.getbuffer())
+
+    # 3. Extract the comment ID and change ID to prepare our batch actions
+    text_mid = extract_text_from_stream(stream_mid)
+    com_match = re.search(r"\[Com:(\d+)\]", text_mid)
+    chg_match = re.search(r"\[Chg:(\d+)", text_mid)
+
+    assert com_match, "Comment ID not found in document text"
+    assert chg_match, "Change ID not found in document text"
+
+    com_id = f"Com:{com_match.group(1)}"
+    chg_id = f"Chg:{chg_match.group(1)}"
+
+    # 4. Construct a batch array where AcceptChange comes BEFORE ReplyComment
+    batch_data = [
+        {"type": "accept", "target_id": chg_id},
+        {"type": "reply", "target_id": com_id, "text": "This reply is evaluated too late."},
+    ]
+    with open(batch_json_path, "w", encoding="utf-8") as f:
+        json.dump(batch_data, f)
+
+    # 5. Run the apply CLI command to apply this batch of review actions
+    rc_apply = _run_cli(["apply", str(updated_docx_path), str(batch_json_path), "-o", str(out_path)])
+
+    # This asserts the CORRECT expected behavior:
+    # Under the bug, apply fails (returns non-zero exit code 1) because
+    # the comment is deleted prior to the reply being applied.
+    # When fixed, it should succeed (return 0) and write out the file.
+    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply} due to strict action ordering constraint"
+    assert out_path.exists(), "Applied output docx was not written"


### PR DESCRIPTION
## Pull Request Overview

Please provide a brief description of the changes introduced by this PR.

---

## 🛑 Ecosystem / Vendor Integrations (READ FIRST)
*If you are submitting a new third-party integration, API connector, or LegalTech tool to the `ecosystem/` directory, you **must** complete this checklist. PRs that fail to meet these criteria will be automatically closed without review.*

- [ ] **Zero Core Coupling:** I confirm this PR does NOT modify `src/adeu/` or `node/packages/core/`. All execution logic is self-contained or strictly uses approved callback/middleware hooks.
- [ ] **Strict Dependency Isolation:** I have included a dedicated package manager file (`pyproject.toml` or `package.json`) exclusively within my `ecosystem/<plugin>/` directory. My dependencies do not pollute the root lockfiles.
- [ ] **No Hoisting / Phantom Dependencies:** I am using explicit workspace protocols (e.g., `workspace:*` or `adeu = { path = "../../python" }`) to reference the core engine.
- [ ] **Commercial Transparency:** If my integration requires a paid subscription, API key, or routes to a closed-source endpoint, it is explicitly declared at the very top of my `README.md`.
- [ ] **14-Day Maintenance SLA:** I have read and agree to the `VENDOR_POLICY.md`. I acknowledge that I am responsible for the perpetual OpEx of this code. If this integration breaks and I fail to resolve the issue within 14 days, I understand the integration will be aggressively pruned/deleted.

---

## 🛠️ Core Engine Contributions
*If you are contributing to the core Adeu OpenXML parsing engine or standard MCP tooling:*

- [ ] I have added a regression test (e.g., `tests/test_repro_issue_name.py`) to prove the bug is fixed or the feature handles Edge-Case OpenXML correctly.
- [ ] I have verified that changes to `RedlineEngine` do not cause silent DOM corruption (e.g., bypassing `w:ins`/`w:del` tags).
- [ ] I have run the formatting and linting suite (`uv run ruff format .` and `uv run mypy src`).
- [ ] (If applicable) I have tested this against Live MS Word via COM (`live_word.py`) to ensure parity between Disk and Live operations.

## Related Issues
Closes # (Issue Number)