### PR TITLE
fix: keep wrapping comments when accepting tracked changes

### DIFF
--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -4082,11 +4082,13 @@ class RedlineEngine:
 
         return applied, skipped, already_resolved
 
-    def _clean_wrapping_comments(self, element):
+    def _clean_wrapping_comments(self, element, preserve_comments: bool = False):
         """
         Removes comment anchors that tightly wrap this element (or a paired del/ins).
         This prevents orphaned comment ranges from leaking when an edit is accepted/rejected.
         """
+        if preserve_comments:
+            return
         first_node = element
         while True:
             prev = first_node.getprevious()
@@ -4193,7 +4195,7 @@ class RedlineEngine:
             resolved_ids.add(node.get(qn("w:id")))
 
         for ins in all_ins:
-            self._clean_wrapping_comments(ins)
+            self._clean_wrapping_comments(ins, preserve_comments=True)
             parent = ins.getparent()
             if parent is None:
                 continue
@@ -4209,7 +4211,7 @@ class RedlineEngine:
             parent.remove(ins)
 
         for d in all_del:
-            self._clean_wrapping_comments(d)
+            self._clean_wrapping_comments(d, preserve_comments=False)
             self._delete_comments_in_element(d)
             parent = d.getparent()
             if parent is not None:
@@ -4241,7 +4243,7 @@ class RedlineEngine:
             resolved_ids.add(node.get(qn("w:id")))
 
         for ins in all_ins:
-            self._clean_wrapping_comments(ins)
+            self._clean_wrapping_comments(ins, preserve_comments=False)
             self._delete_comments_in_element(ins)
             parent = ins.getparent()
             if parent is None:
@@ -4275,7 +4277,7 @@ class RedlineEngine:
             parent.remove(ins)
 
         for d in all_del:
-            self._clean_wrapping_comments(d)
+            self._clean_wrapping_comments(d, preserve_comments=True)
             parent = d.getparent()
             if parent is None:
                 continue
@@ -4370,7 +4372,7 @@ class RedlineEngine:
 
         for root_element in parts_to_process:
             for ins in root_element.findall(f".//{qn('w:ins')}"):
-                self._clean_wrapping_comments(ins)
+                self._clean_wrapping_comments(ins, preserve_comments=True)
                 parent = ins.getparent()
                 if parent is None:
                     continue
@@ -4412,13 +4414,13 @@ class RedlineEngine:
                         if has_content:
                             rPr.remove(del_mark)
                         else:
-                            self._clean_wrapping_comments(p)
+                            self._clean_wrapping_comments(p, preserve_comments=False)
                             self._delete_comments_in_element(p)
                             if p.getparent() is not None:
                                 p.getparent().remove(p)
 
             for d in root_element.findall(f".//{qn('w:del')}"):
-                self._clean_wrapping_comments(d)
+                self._clean_wrapping_comments(d, preserve_comments=False)
                 self._delete_comments_in_element(d)
                 parent = d.getparent()
                 if parent is not None:
@@ -4547,7 +4549,7 @@ class RedlineEngine:
                 parent = ins.getparent()
                 if parent is None:
                     continue
-                self._clean_wrapping_comments(ins)
+                self._clean_wrapping_comments(ins, preserve_comments=False)
                 self._delete_comments_in_element(ins)
                 if parent.tag == qn("w:trPr"):
                     row = parent.getparent()
@@ -4571,7 +4573,7 @@ class RedlineEngine:
                 parent = d.getparent()
                 if parent is None:
                     continue
-                self._clean_wrapping_comments(d)
+                self._clean_wrapping_comments(d, preserve_comments=True)
                 if parent.tag == qn("w:trPr"):
                     parent.remove(d)
                     continue

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -145,3 +145,77 @@ def test_apply_comment_reply_order_repro(tmp_path):
     # When fixed, it should succeed (return 0) and write out the file.
     assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply} due to strict action ordering constraint"
     assert out_path.exists(), "Applied output docx was not written"
+
+
+def test_silent_comment_deletion_on_accept(tmp_path):
+    """
+    Test that accepting a tracked change (e.g., an insertion or deletion)
+    successfully preserves any associated comment thread attached to that text block.
+
+    Under the bug, the accept action silently deletes the comment range anchors
+    from the main document body, causing quiet data loss. When fixed, accepting
+    the tracked change should promote/commit the text but keep the comments and
+    all of their existing replies.
+    """
+    import io
+    import json
+    import re
+
+    from adeu.ingest import extract_text_from_stream
+    from adeu.models import ModifyText
+    from adeu.redline.engine import RedlineEngine
+
+    docx_path = tmp_path / "original.docx"
+    updated_docx_path = tmp_path / "updated.docx"
+    batch_json_path = tmp_path / "batch.json"
+    out_path = tmp_path / "applied.docx"
+
+    # 1. Create a baseline docx file
+    doc = Document()
+    doc.add_paragraph("The quick brown fox jumps.")
+    doc.save(docx_path)
+
+    # 2. Add a tracked change + comment
+    with open(docx_path, "rb") as f:
+        stream = io.BytesIO(f.read())
+
+    engine = RedlineEngine(stream, author="Author1")
+    edit = ModifyText(target_text="fox", new_text="cat", comment="This is our critical comment thread context.")
+    engine.apply_edits([edit])
+
+    stream_mid = engine.save_to_stream()
+    with open(updated_docx_path, "wb") as f:
+        f.write(stream_mid.getbuffer())
+
+    # 3. Extract the comment ID and change ID to prepare our batch actions
+    text_mid = extract_text_from_stream(stream_mid)
+    com_match = re.search(r"\[Com:(\d+)\]", text_mid)
+    chg_match = re.search(r"\[Chg:(\d+)", text_mid)
+
+    assert com_match, "Comment ID not found in intermediate text"
+    assert chg_match, "Change ID not found in intermediate text"
+
+    com_id = f"Com:{com_match.group(1)}"
+    chg_id = f"Chg:{chg_match.group(1)}"
+
+    # 4. Construct a batch array containing only the accept action for the change
+    batch_data = [{"type": "accept", "target_id": chg_id}]
+    with open(batch_json_path, "w", encoding="utf-8") as f:
+        json.dump(batch_data, f)
+
+    # 5. Run the apply CLI command to apply this accept action
+    rc_apply = _run_cli(["apply", str(updated_docx_path), str(batch_json_path), "-o", str(out_path)])
+    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
+    assert out_path.exists(), "Applied output docx was not written"
+
+    # 6. Extract the text of the generated document and verify that the comment has been preserved
+    rc_extract = _run_cli(["extract", str(out_path)])
+    assert rc_extract == 0, "CLI extract failed"
+
+    with open(out_path, "rb") as f:
+        applied_stream = io.BytesIO(f.read())
+    text_applied = extract_text_from_stream(applied_stream)
+
+    # Under the bug, the comment [Com:1] is deleted, so the next assertion fails.
+    # When fixed, the comment is preserved, and the assertion passes.
+    assert f"[{com_id}]" in text_applied, f"Comment {com_id} was silently deleted when accepting change {chg_id}"


### PR DESCRIPTION
## Agentic Auto-Fix

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
## Root Cause
When applying review actions using `adeu apply`, accepting a tracked change (e.g. an insertion `w:ins`) or rejecting a tracked deletion (`w:del`) promotes or restores the underlying text and commits it into the main body of the document.
However, the XML parsing logic in the redline engine (`src/adeu/redline/engine.py`) unconditionally called `_clean_wrapping_comments(element)` for all insertions and deletions being processed, regardless of whether the text was being kept or removed.
`_clean_wrapping_comments` scans for comment range anchors (`w:commentRangeStart` and `w:commentRangeEnd`) that tightly wrap the change element. If both start and end tags wrap the element, the comment is deleted from the body and from `comments.xml` to prevent "orphaned" comment ranges.
While this behavior is correct when deleting text (rejecting an insertion or accepting a deletion), it is completely destructive when the text is preserved (accepting an insertion or rejecting a deletion), as it silently deletes perfectly valid comment threads and all of their replies, causing S1 severe data loss.

## The Fix
The fix was implemented directly at the systemic redline engine layer inside `src/adeu/redline/engine.py`:
1. Updated `_clean_wrapping_comments(self, element)` to support a boolean flag: `_clean_wrapping_comments(self, element, preserve_comments: bool = False)`. When `preserve_comments` is `True`, the function returns early and leaves the comment ranges untouched, wrapping the newly promoted or restored text run.
2. Updated all call sites of `_clean_wrapping_comments` in the codebase to pass `preserve_comments=True` when text is kept (accepting insertions, rejecting deletions), and `preserve_comments=False` when text is deleted (rejecting insertions, accepting deletions).
   - In `_accept_change`:
     - Set `preserve_comments=True` for accepted insertions (`all_ins`).
     - Set `preserve_comments=False` for accepted deletions (`all_del`).
   - In `_reject_change`:
     - Set `preserve_comments=False` for rejected insertions (`all_ins`).
     - Set `preserve_comments=True` for rejected deletions (`all_del`).
   - In `accept_all_revisions`:
     - Set `preserve_comments=True` for accepted insertions (`w:ins`).
     - Set `preserve_comments=False` for accepted paragraphs (`p`) and deletions (`w:del`).
   - In `reject_all_revisions`:
     - Set `preserve_comments=False` for rejected insertions (`w:ins`).
     - Set `preserve_comments=True` for rejected deletions (`w:del`).

## Sibling Occurrences
All 9 call sites of `_clean_wrapping_comments` inside `src/adeu/redline/engine.py` (representing all places where tracked change acceptance/rejection occurs) were audited and systematically unified. In every single place where text is kept, the comment is now preserved, and where text is deleted, the comment is cleaned up as originally intended. No other occurrences of this pattern exist in the codebase.

## Verification
The following validation and verification runs were successfully executed:
1. **Regression Tests**:
   - `uv run pytest tests/test_cli_bug_repro.py` successfully passes with 3/3 tests green, verifying that accepting a tracked change preserves associated comment threads and replies, and resolves action ordering constraints.
2. **Full Python Test Suite**:
   - `uv run pytest` executed 911 tests with 871 passes and 40 skipped (unrelated, COM/Windows-only tests), with 0 failures or regressions.
3. **Format & Linting**:
   - `uv run ruff check --fix .` and `uv run ruff format .` ran cleanly with all checks passed and touched files beautifully formatted.
4. **Static Type Checking**:
   - `uv run mypy src` successfully passed with 0 issues across 30 source files.
5. **Node/TS Consistency Tests**:
   - Built and ran TS tests using `npm install && npm run build && npm test` inside `adeu_isolated/node`. All 358 tests across packages (`@adeu/core`, `@adeu/mcp-server`, `n8n-nodes-adeu`) passed cleanly.

## Risk Assessment
The risk of this change is extremely low, as it precisely limits the scope of comment cleanup only to scenarios where text is physically deleted. Under normal operations where text is kept, Word comments are left intact, mirroring the exact, standard behavior of Microsoft Word desktop application. No new CLI options or MCP tools were introduced, keeping the public interface frozen and lightweight.


<details><summary>Reproduction Report</summary>

# Agent QA Automation Bug Report

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

## The Bug & Severity
- **Description**: When applying review actions to a Microsoft Word document containing tracked changes and comments with `adeu apply`, accepting a tracked change (`AcceptChange`) that has an associated comment thread causes the comment ranges (`w:commentRangeStart` and `w:commentRangeEnd`) to be silently and cleanly stripped from the document body XML. This results in the complete deletion of the entire comment thread (and all replies) from the document, leading to silent data loss without any warning or non-zero exit code.
- **Severity**: **S1 (Data Loss)**

---

## Minimal Reproduction

### 1. Input Files

`inputs/only_accept.json`:
```json
[
  {
    "type": "accept",
    "target_id": "Chg:2"
  }
]
```

`inputs/comments_tracked.docx`:
A Word document containing comment `Com:1` wrapping the tracked change insertion `Chg:2`.

### 2. Reproduction Commands
```bash
# 1. Apply the accept action using adeu apply
.venv/bin/adeu apply inputs/comments_tracked.docx inputs/only_accept.json -o outputs/only_accept.docx

# 2. Extract the text of the generated document using adeu extract
.venv/bin/adeu extract outputs/only_accept.docx
```

### 3. Actual vs. Expected Output
- **Actual (Bug)**: The extraction output does not contain the comment reference `[Com:1]`. The comment is completely deleted.
- **Expected (Success)**: The extraction output must preserve the comment `[Com:1]` attached to the text block.

---

## The Regression Test Code
The regression test has been written into `tests/test_cli_bug_repro.py`.

```python
def test_silent_comment_deletion_on_accept(tmp_path):
    """
    Test that accepting a tracked change (e.g., an insertion or deletion)
    successfully preserves any associated comment thread attached to that text block.

    Under the bug, the accept action silently deletes the comment range anchors
    from the main document body, causing quiet data loss. When fixed, accepting
    the tracked change should promote/commit the text but keep the comments and
    all of their existing replies.
    """
    import io
    import json
    import re

    from adeu.ingest import extract_text_from_stream
    from adeu.models import ModifyText
    from adeu.redline.engine import RedlineEngine

    docx_path = tmp_path / "original.docx"
    updated_docx_path = tmp_path / "updated.docx"
    batch_json_path = tmp_path / "batch.json"
    out_path = tmp_path / "applied.docx"

    # 1. Create a baseline docx file
    doc = Document()
    doc.add_paragraph("The quick brown fox jumps.")
    doc.save(docx_path)

    # 2. Add a tracked change + comment
    with open(docx_path, "rb") as f:
        stream = io.BytesIO(f.read())

    engine = RedlineEngine(stream, author="Author1")
    edit = ModifyText(target_text="fox", new_text="cat", comment="This is our critical comment thread context.")
    engine.apply_edits([edit])

    stream_mid = engine.save_to_stream()
    with open(updated_docx_path, "wb") as f:
        f.write(stream_mid.getbuffer())

    # 3. Extract the comment ID and change ID to prepare our batch actions
    text_mid = extract_text_from_stream(stream_mid)
    com_match = re.search(r"\[Com:(\d+)\]", text_mid)
    chg_match = re.search(r"\[Chg:(\d+)", text_mid)

    assert com_match, "Comment ID not found in intermediate text"
    assert chg_match, "Change ID not found in intermediate text"

    com_id = f"Com:{com_match.group(1)}"
    chg_id = f"Chg:{chg_match.group(1)}"

    # 4. Construct a batch array containing only the accept action for the change
    batch_data = [
        {"type": "accept", "target_id": chg_id}
    ]
    with open(batch_json_path, "w", encoding="utf-8") as f:
        json.dump(batch_data, f)

    # 5. Run the apply CLI command to apply this accept action
    rc_apply = _run_cli(["apply", str(updated_docx_path), str(batch_json_path), "-o", str(out_path)])
    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
    assert out_path.exists(), "Applied output docx was not written"

    # 6. Extract the text of the generated document and verify that the comment has been preserved
    rc_extract = _run_cli(["extract", str(out_path)])
    assert rc_extract == 0, "CLI extract failed"

    with open(out_path, "rb") as f:
        applied_stream = io.BytesIO(f.read())
    text_applied = extract_text_from_stream(applied_stream)

    # Under the bug, the comment [Com:1] is deleted, so the next assertion fails.
    # When fixed, the comment is preserved, and the assertion passes.
    assert f"[{com_id}]" in text_applied, f"Comment {com_id} was silently deleted when accepting change {chg_id}"
```

---

## Pytest Failure Output

```
=================================== FAILURES ===================================
____________________ test_silent_comment_deletion_on_accept ____________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-83/test_silent_comment_deletion_o0')

    def test_silent_comment_deletion_on_accept(tmp_path):
...
        # Under the bug, the comment [Com:1] is deleted, so the next assertion fails.
        # When fixed, the comment is preserved, and the assertion passes.
>       assert f"[{com_id}]" in text_applied, f"Comment {com_id} was silently deleted when accepting change {chg_id}"
E       AssertionError: Comment Com:1 was silently deleted when accepting change Chg:1
E       assert '[Com:1]' in 'The quick brown cat jumps.'

tests/test_cli_bug_repro.py:223: AssertionError
----------------------------- Captured stdout call -----------------------------
> **File Path:** `/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-83/test_silent_comment_deletion_o0/applied.docx`

The quick brown cat jumps.
----------------------------- Captured stderr call -----------------------------
Loading structured batch from /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-83/test_silent_comment_deletion_o0/batch.json...
Applying 1 changes to updated.docx...
Batch complete. Saved to: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-83/test_silent_comment_deletion_o0/applied.docx
Actions: 1 applied, 0 skipped.
Edits: 0 applied, 0 skipped.
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_silent_comment_deletion_on_accept - AssertionError: Comment Com:1 was silently deleted when accepting change Chg:1
================== 1 failed, 870 passed, 40 skipped in 53.43s ==================
```

---

## Acceptance Criteria For Fix Stage
Once the bug is successfully fixed:
1. Running `adeu apply` with an accept action for a change that has overlapping/associated comment anchors must preserve all such comment tags (`w:commentRangeStart`, `w:commentRangeEnd`, `w:commentReference`) and prevent them from being stripped.
2. The entire comment thread (the parent comment and all existing replies) must remain attached to the newly accepted text in the document.
3. The regression test suite (`uv run pytest tests/test_cli_bug_repro.py`) must pass completely with `0` failures.


</details>
