### PR TITLE
fix: tag --live option as Windows-only on non-Windows OS

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1685,12 +1685,14 @@ def _main_impl():
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     subparsers = parser.add_subparsers(dest="command", required=True, help="Subcommands")
 
+    live_help_prefix = "Windows-only: " if sys.platform != "win32" else ""
+
     p_extract = subparsers.add_parser("extract", help="Extract raw text from a DOCX file")
     p_extract.add_argument("input", type=Path, nargs="?", help="Input DOCX file (omit if --live)")
     p_extract.add_argument(
         "--live",
         action="store_true",
-        help="Extract text from live active Word document",
+        help=f"{live_help_prefix}Extract text from live active Word document",
     )
     p_extract.add_argument("-o", "--output", type=Path, help="Output file ('-' or omitted: stdout)")
     p_extract.add_argument(
@@ -1803,7 +1805,11 @@ def _main_impl():
     )
     p_apply.add_argument("original", type=Path, nargs="?", help="Original DOCX (omit if --live)")
     p_apply.add_argument("changes", type=Path, nargs="?", help="JSON edits file OR Modified Text file")
-    p_apply.add_argument("--live", action="store_true", help="Apply edits to live active Word document")
+    p_apply.add_argument(
+        "--live",
+        action="store_true",
+        help=f"{live_help_prefix}Apply edits to live active Word document",
+    )
     p_apply.add_argument("-o", "--output", type=Path, help="Output DOCX path")
     p_apply.add_argument(
         "--author",

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -219,3 +219,47 @@ def test_silent_comment_deletion_on_accept(tmp_path):
     # Under the bug, the comment [Com:1] is deleted, so the next assertion fails.
     # When fixed, the comment is preserved, and the assertion passes.
     assert f"[{com_id}]" in text_applied, f"Comment {com_id} was silently deleted when accepting change {chg_id}"
+
+
+def test_mac_live_flag_help_warning(capsys):
+    """
+    Test that on non-Windows platforms (like macOS and Linux),
+    the help text for both 'extract' and 'apply' commands either hides the '--live' option
+    or clearly designates it as Windows-only.
+    """
+    import sys
+    from unittest.mock import patch
+
+    import pytest
+
+    from adeu.cli import main
+
+    if sys.platform == "win32":
+        pytest.skip("This check is for non-Windows platforms (macOS/Linux) where --live is unsupported.")
+
+    # 1. Check extract help
+    with patch.object(sys, "argv", ["adeu", "extract", "--help"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    out_extract = capsys.readouterr().out
+
+    # 2. Check apply help
+    with patch.object(sys, "argv", ["adeu", "apply", "--help"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    out_apply = capsys.readouterr().out
+
+    # Assert that '--live' is either not present or is labeled as Windows-only / Windows only
+    # Under the bug, '--live' is present but has no platform warning, so the assertion fails.
+    # When fixed, it should either be omitted or have an explicit "Windows-only" warning.
+    for cmd_name, out in [("extract", out_extract), ("apply", out_apply)]:
+        if "--live" in out:
+            # Option is exposed, so it must mention that it is Windows-only
+            assert "Windows-only" in out or "Windows only" in out, (
+                f"The '--live' option help message in '{cmd_name}' must clearly state "
+                "that it is Windows-only on non-Windows platforms."
+            )


### PR DESCRIPTION
## Agentic Auto-Fix

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
## Root Cause
On non-Windows platforms (like macOS and Linux), running the `adeu` CLI help commands (`extract --help` and `apply --help`) exposed the `--live` flag without indicating that it is unsupported on non-Windows operating systems. While executing `--live` on macOS/Linux correctly exited with code 1 and printed `❌ --live is only supported on Windows.`, the help text had no platform designations.

Furthermore, `argparse`'s default text wrapper wraps lines at terminal boundary limits (e.g. 80 columns) and automatically breaks hyphenated words such as `(Windows-only)` at the hyphen, or wraps on space (e.g., `(Windows only)` split as `(Windows` and `only)`). This splitting caused substring assertion checks in the test suite to fail on standard-width terminal outputs because the target term was broken across a newline boundary.

## The Fix
The fix is implemented directly in the CLI entry point at `src/adeu/cli.py` within `_main_impl()`. This layer is the optimal place to handle this as it isolates the CLI presentation/argument definitions.

1. Added a dynamic platform check to compute a help prefix:
   ```python
   live_help_prefix = "Windows-only: " if sys.platform != "win32" else ""
   ```
2. Prepended this prefix to the `--live` option description in both the `extract` and `apply` subcommand parser registrations:
   - **`extract`**: `help=f"{live_help_prefix}Extract text from live active Word document"`
   - **`apply`**: `help=f"{live_help_prefix}Apply edits to live active Word document"`

Placing the dynamic warning prefix at the beginning of the help text ensures that `"Windows-only"` sits near the start of the option description (starting around column 24), which is far away from the line wrapping boundary (typically column 80). This guarantees that `"Windows-only"` is printed contiguously on a single line and matches test assertion checks flawlessly.

## Sibling Occurrences
A complete scan of the command-line surface was performed to check for any other commands implementing `--live` or similar Windows-specific/platform-restricted flags.
- **`extract`** and **`apply`** are the only two subcommands displaying `--live`. No other sibling commands contain this flag.
- There are no other platform-specific arguments in the codebase.

## Verification
A thorough validation was performed locally from `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python`:
1. **Regression test**: `uv run pytest tests/test_cli_bug_repro.py::test_mac_live_flag_help_warning` passes cleanly.
2. **Full Python test suite**: `uv run pytest` executed 912 tests. Result: `872 passed, 40 skipped` with **zero failures**.
3. **Linter & Formatter**: Running `uv run ruff check --fix . && uv run ruff format .` passed successfully with **all checks passed** and the touched code properly formatted.
4. **Type Check**: `uv run mypy src` reported **Success: no issues found in 30 source files**.
5. **Cross-Engine consistency tests**: Node integration tests under `adeu_isolated/node` were built and tested via `npm install && npm run build && npm test`. All packages and test suites passed successfully with **zero failures** (427 total vitest tests passed).

## Risk Assessment & Follow-Ups
- **Risk**: Extremely low. This is a purely cosmetic adjustment to the CLI help string that dynamically resolves at runtime based on `sys.platform`. It has zero impact on core compilation, XML generation, document diffing, or serialization logic.
- **Suggested Follow-Ups**: Ensure future CLI options that are platform-specific (if any are added) adopt the same prefix pattern to guarantee consistency and avoid line wrapping issues in automated output assertion checks.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

## The Bug & Severity
- **Description**: On non-Windows platforms (like macOS and Linux), running the `adeu` CLI help commands (`extract --help` and `apply --help`) exposes and displays the `--live` option without indicating that it is unsupported on those operating systems. Running `--live` on macOS/Linux correctly exits with code 1 and prints `❌ --live is only supported on Windows.`, but the CLI's `--help` text contains no platform designation or dynamically hidden entries.
- **Severity**: **Cosmetic/Low**

---

## Minimal Reproduction

### 1. Reproduction Commands
```bash
# On a macOS or Linux machine:
uv run adeu extract --help
uv run adeu apply --help
```

### 2. Actual vs. Expected Output
- **Actual**: Both help pages list `--live` as an option with description strings that do not indicate platform restrictions:
  - `  --live                Extract text from live active Word document`
  - `  --live                Apply edits to live active Word document`
- **Expected**: The CLI on non-Windows platforms should either dynamically hide the `--live` flag from the help text entirely, or append a clarifying warning such as `(Windows-only)` to its help description.

---

## The Regression Test Code
The regression test has been appended to the test suite at `tests/test_cli_bug_repro.py`:

```python
def test_mac_live_flag_help_warning(capsys):
    """
    Test that on non-Windows platforms (like macOS and Linux),
    the help text for both 'extract' and 'apply' commands either hides the '--live' option
    or clearly designates it as Windows-only.
    """
    import sys
    import pytest
    from unittest.mock import patch
    from adeu.cli import main

    if sys.platform == "win32":
        pytest.skip("This check is for non-Windows platforms (macOS/Linux) where --live is unsupported.")

    # 1. Check extract help
    with patch.object(sys, "argv", ["adeu", "extract", "--help"]):
        with pytest.raises(SystemExit) as exc_info:
            main()
        assert exc_info.value.code == 0

    out_extract = capsys.readouterr().out
    
    # 2. Check apply help
    with patch.object(sys, "argv", ["adeu", "apply", "--help"]):
        with pytest.raises(SystemExit) as exc_info:
            main()
        assert exc_info.value.code == 0

    out_apply = capsys.readouterr().out

    # Assert that '--live' is either not present or is labeled as Windows-only / Windows only
    # Under the bug, '--live' is present but has no platform warning, so the assertion fails.
    # When fixed, it should either be omitted or have an explicit "Windows-only" warning.
    for cmd_name, out in [("extract", out_extract), ("apply", out_apply)]:
        if "--live" in out:
            # Option is exposed, so it must mention that it is Windows-only
            assert "Windows-only" in out or "Windows only" in out, (
                f"The '--live' option help message in '{cmd_name}' must clearly state "
                "that it is Windows-only on non-Windows platforms."
            )
```

---

## Pytest Failure Output

```
=================================== FAILURES ===================================
_______________________ test_mac_live_flag_help_warning ________________________

capsys = <_pytest.capture.CaptureFixture object at 0x108fccf70>

    def test_mac_live_flag_help_warning(capsys):
        """
        Test that on non-Windows platforms (like macOS and Linux),
        the help text for both 'extract' and 'apply' commands either hides the '--live' option
        or clearly designates it as Windows-only.
        """
        import sys
        import pytest
        from unittest.mock import patch
        from adeu.cli import main
    
        if sys.platform == "win32":
            pytest.skip("This check is for non-Windows platforms (macOS/Linux) where --live is unsupported.")
    
        # 1. Check extract help
        with patch.object(sys, "argv", ["adeu", "extract", "--help"]):
            with pytest.raises(SystemExit) as exc_info:
                main()
            assert exc_info.value.code == 0
    
        out_extract = capsys.readouterr().out
    
        # 2. Check apply help
        with patch.object(sys, "argv", ["adeu", "apply", "--help"]):
            with pytest.raises(SystemExit) as exc_info:
                main()
            assert exc_info.value.code == 0
    
        out_apply = capsys.readouterr().out
    
        # Assert that '--live' is either not present or is labeled as Windows-only / Windows only
        # Under the bug, '--live' is present but has no platform warning, so the assertion fails.
        # When fixed, it should either be omitted or have an explicit "Windows-only" warning.
        for cmd_name, out in [("extract", out_extract), ("apply", out_apply)]:
            if "--live" in out:
                # Option is exposed, so it must mention that it is Windows-only
>               assert "Windows-only" in out or "Windows only" in out, (
                    f"The '--live' option help message in '{cmd_name}' must clearly state "
                    "that it is Windows-only on non-Windows platforms."
                )
E               AssertionError: The '--live' option help message in 'extract' must clearly state that it is Windows-only on non-Windows platforms.
E               assert ('Windows-only' in 'usage: adeu extract [-h] [--live] [-o OUTPUT] [--clean-view]\n                    [--mode {full,outline,appendix}] [-...json                Emit the extraction result as a machine-readable JSON\n                        object on stdout.\n' or 'Windows only' in 'usage: adeu extract [-h] [--live] [-o OUTPUT] [--clean-view]\n                    [--mode {full,outline,appendix}] [-...json                Emit the extraction result as a machine-readable JSON\n                        object on stdout.\n')

tests/test_cli_bug_repro.py:260: AssertionError
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_mac_live_flag_help_warning - AssertionError: The '--live' option help message in 'extract' must clearly state that it is Windows-only on non-Windows platforms.
```

---

## Expected Behavior Once Fixed (Acceptance Criteria)
1. On non-Windows platforms (macOS, Linux), the CLI `--help` text for the `extract` and `apply` commands should either omit `--live` completely, or explicitly suffix/mention that it is Windows-only (e.g., `(Windows-only)`).
2. Running the test suite via `uv run pytest` inside `adeu_isolated/python` must pass with `0` failures once the fix has been applied.


</details>
