### PR TITLE
fix: detailed report prints table row modification indications

### DIFF
--- a/node/packages/core/src/engine.tables.test.ts
+++ b/node/packages/core/src/engine.tables.test.ts
@@ -265,4 +265,35 @@ describe("Table Interop & Engine (Node.js Port)", () => {
     expect(errors[0]).toContain('Did you mean the literal "( x )"');
     expect(errors[0]).toContain("drop the ^/$ anchors");
   });
+
+  it("compiled report includes type for structural table operations", async () => {
+    const doc = await createTestDocument();
+    const tbl = addTable(doc, 2, 2);
+    setCellText(tbl, 0, 0, "Row1 Col1");
+    setCellText(tbl, 0, 1, "Row1 Col2");
+    setCellText(tbl, 1, 0, "Row2 Col1");
+    setCellText(tbl, 1, 1, "Row2 Col2");
+
+    const buf = await doc.save();
+    const midDoc = await DocumentObject.load(buf);
+    const engine = new RedlineEngine(midDoc);
+
+    const stats = engine.process_batch([
+      {
+        type: "insert_row",
+        target_text: "Row1 Col1",
+        position: "below",
+        cells: ["NewRow Col1", "NewRow Col2"],
+      } as InsertTableRow,
+      {
+        type: "delete_row",
+        target_text: "Row2 Col1",
+      } as DeleteTableRow,
+    ]);
+
+    expect(stats.edits_applied).toBe(2);
+    expect(stats.edits).toHaveLength(2);
+    expect(stats.edits[0].type).toBe("insert_row");
+    expect(stats.edits[1].type).toBe("delete_row");
+  });
 });

--- a/node/packages/core/src/engine.ts
+++ b/node/packages/core/src/engine.ts
@@ -2893,6 +2893,7 @@ export class RedlineEngine {
             );
             reports_by_input[i] = {
               status: "failed",
+              type: (edit as any).type || "modify",
               target_text: truncate_middle((edit as any).target_text || "", REPORT_ECHO_CAP),
               new_text: truncate_middle(RedlineEngine._report_new_text(edit), REPORT_ECHO_CAP),
               warning: warning,
@@ -2908,6 +2909,7 @@ export class RedlineEngine {
             const previews = this._build_edit_context_previews(edit);
             reports_by_input[i] = {
               status: "applied",
+              type: (edit as any).type || "modify",
               target_text: truncate_middle((edit as any).target_text || "", REPORT_ECHO_CAP),
               new_text: truncate_middle(RedlineEngine._report_new_text(edit), REPORT_ECHO_CAP),
               warning: null,
@@ -2932,6 +2934,7 @@ export class RedlineEngine {
             );
             reports_by_input[i] = {
               status: "failed",
+              type: (edit as any).type || "modify",
               target_text: truncate_middle((edit as any).target_text || "", REPORT_ECHO_CAP),
               new_text: truncate_middle(RedlineEngine._report_new_text(edit), REPORT_ECHO_CAP),
               warning: warning,
@@ -2954,6 +2957,7 @@ export class RedlineEngine {
             if (report.status === "applied") {
               reports_by_input[i] = {
                 status: "failed",
+                type: report.type || "modify",
                 target_text: report.target_text,
                 new_text: report.new_text,
                 warning: null,
@@ -3030,6 +3034,7 @@ export class RedlineEngine {
           }
           edits_reports.push({
             status: success ? "applied" : "failed",
+            type: (edit as any).type || "modify",
             target_text: truncate_middle((edit as any).target_text || "", REPORT_ECHO_CAP),
             new_text: truncate_middle(RedlineEngine._report_new_text(edit), REPORT_ECHO_CAP),
             warning: warning,

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1210,7 +1210,13 @@ def handle_apply(args):
                 status_indicator = "✅ [applied]" if report["status"] == "applied" else "❌ [failed]"
                 print(f"Edit {i + 1} {status_indicator}:", file=sys.stderr)
                 print(f"  Target: '{report['target_text']}'", file=sys.stderr)
-                print(f"  New text: '{report['new_text']}'", file=sys.stderr)
+                edit_type = report.get("type", "modify")
+                if edit_type == "insert_row":
+                    print(f"  Inserted row: '{report['new_text']}'", file=sys.stderr)
+                elif edit_type == "delete_row":
+                    print("  Deleted row", file=sys.stderr)
+                else:
+                    print(f"  New text: '{report['new_text']}'", file=sys.stderr)
                 if report.get("warning"):
                     print(f"  Warning: {report['warning']}", file=sys.stderr)
                 if report.get("error"):

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -2052,6 +2052,7 @@ class RedlineEngine:
             warning = self._check_punctuation_warning(getattr(edit, "target_text", ""))
         return {
             "status": "applied" if success else "failed",
+            "type": getattr(edit, "type", "modify"),
             # Echoes of caller-supplied values are bounded so an oversized edit
             # cannot balloon the report/JSON output (QA C2).
             "target_text": truncate_middle(getattr(edit, "target_text", ""), REPORT_ECHO_CAP),
@@ -2180,6 +2181,7 @@ class RedlineEngine:
                     skipped_edits += 1
                     reports_by_input[i] = {
                         "status": "failed",
+                        "type": getattr(e, "type", "modify"),
                         "target_text": truncate_middle(getattr(e, "target_text", ""), REPORT_ECHO_CAP),
                         "new_text": truncate_middle(self._report_new_text(e), REPORT_ECHO_CAP),
                         "warning": None,
@@ -2223,6 +2225,7 @@ class RedlineEngine:
                     warning = self._check_punctuation_warning(getattr(edit, "target_text", ""))
                     reports_by_input[i] = {
                         "status": "failed",
+                        "type": getattr(edit, "type", "modify"),
                         "target_text": truncate_middle(getattr(edit, "target_text", ""), REPORT_ECHO_CAP),
                         "new_text": truncate_middle(self._report_new_text(edit), REPORT_ECHO_CAP),
                         "warning": warning,
@@ -2254,6 +2257,7 @@ class RedlineEngine:
                         continue
                     reports_by_input[i] = {
                         "status": "failed",
+                        "type": report.get("type", "modify"),
                         "target_text": report["target_text"],
                         "new_text": report["new_text"],
                         "warning": None,

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -263,3 +263,63 @@ def test_mac_live_flag_help_warning(capsys):
                 f"The '--live' option help message in '{cmd_name}' must clearly state "
                 "that it is Windows-only on non-Windows platforms."
             )
+
+
+def test_detailed_report_table_modifications(tmp_path, capsys):
+    """
+    Test that the detailed report printed to sys.stderr by 'adeu apply'
+    displays clear table operation indications ('Inserted row:' and 'Deleted row')
+    for InsertTableRow and DeleteTableRow operations instead of misleading 'New text:' lines.
+    """
+    import json
+
+    docx_path = tmp_path / "doc_tables.docx"
+    edits_path = tmp_path / "edits_tables.json"
+    out_path = tmp_path / "doc_tables_applied.docx"
+
+    # 1. Create a document with a table
+    doc = Document()
+    doc.add_heading("Table Test", level=1)
+    table = doc.add_table(rows=3, cols=2)
+    table.cell(0, 0).text = "Row1 Col1"
+    table.cell(0, 1).text = "Row1 Col2"
+    table.cell(1, 0).text = "Row2 Col1"
+    table.cell(1, 1).text = "Row2 Col2"
+    table.cell(2, 0).text = "Row3 Col1"
+    table.cell(2, 1).text = "Row3 Col2"
+    doc.save(docx_path)
+
+    # 2. Define our structural table edits
+    edits = [
+        {
+            "type": "insert_row",
+            "target_text": "Row1 Col1 | Row1 Col2",
+            "position": "below",
+            "cells": ["NewRow Col1", "NewRow Col2"],
+        },
+        {"type": "delete_row", "target_text": "Row2 Col1"},
+    ]
+    with open(edits_path, "w", encoding="utf-8") as f:
+        json.dump(edits, f)
+
+    # 3. Run adeu apply CLI
+    rc = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(edits_path)])
+    assert rc == 0
+
+    # 4. Capture stderr output
+    captured = capsys.readouterr()
+    err_output = captured.err
+
+    # Under the bug, it prints:
+    #   New text: 'NewRow Col1 | NewRow Col2'
+    # and
+    #   New text: ''
+    # When fixed, it should print:
+    #   Inserted row: 'NewRow Col1 | NewRow Col2'
+    # and
+    #   Deleted row
+    # without displaying "New text:" for these table operations.
+
+    assert "Inserted row: 'NewRow Col1 | NewRow Col2'" in err_output
+    assert "Deleted row" in err_output
+    assert "New text:" not in err_output


### PR DESCRIPTION
## Agentic Auto-Fix

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
## Root Cause
The detailed report formatting in `src/adeu/cli.py` was hardcoded to print `"  New text: '{report['new_text']}'"` for every compiled edit report entry inside `stats["edits"]`. This logic made no distinction between regular text replacements (`ModifyText`) and structural table operations (such as `InsertTableRow` and `DeleteTableRow`). Furthermore, the underlying `RedlineEngine` in both Python and TypeScript did not propagate the `type` attribute of the edit object to the compiled report dictionary, meaning `cli.py` had no way to distinguish the different operation types. Consequently, table row insertions printed a misleading `"New text: '<cells joined>'"` and table row deletions printed `"New text: ''"`, confusing users into thinking simple text edits or text clearing had taken place.

## The Fix
1. **Engine Metadata Propagation (`src/adeu/redline/engine.py`):**
   - Modified `_build_edit_report` and failed/transactional report dictionary builders in `_process_batch_internal` to propagate the `type` attribute of each edit object (defaulting to `"modify"`).
2. **CLI Output Conditional Formatting (`src/adeu/cli.py`):**
   - Updated the detailed edit report printer to inspect the `type` field.
   - For `"insert_row"`, it prints `"  Inserted row: '{report['new_text']}'"` instead of `"  New text: '{report['new_text']}'"`.
   - For `"delete_row"`, it prints `"  Deleted row"` instead of `"  New text: ''"`.
   - For standard `"modify"` text edits, it retains the original `"  New text: ..."` output.
3. **Parity Node.js Engine Metadata Propagation (`node/packages/core/src/engine.ts`):**
   - Performed the exact same metadata propagation changes for wet-run and dry-run report dictionary structures in the TypeScript engine.

## Sibling Occurrences Found
- **Node.js/TypeScript Engine:** Found and resolved the missing `type` metadata propagation sibling inside `node/packages/core/src/engine.ts` for both sequential wet-runs and dry-runs.
- **MCP Server Formatter:** Verified that the python (`src/adeu/mcp_components/tools/document.py`) and typescript (`node/packages/mcp-server/src/index.ts`) MCP tool output formatters do not output raw `"Target:"` or `"New text:"` fields, rendering them unaffected by this issue.

## Verification
- **Regression Test:** Verified that `tests/test_cli_bug_repro.py::test_detailed_report_table_modifications` now passes successfully.
- **Python Full Test Suite:** Ran `uv run pytest` and verified that all **873 tests passed** with zero regressions.
- **Linting & Typing:** Ran `uv run ruff check --fix .` and `uv run ruff format .` (all clean, 0 warnings/errors) and verified that `uv run mypy src` is fully clean.
- **TypeScript Full Test Suite & Parity Test:**
  - Added a new Vitest regression test `"compiled report includes type for structural table operations"` in `node/packages/core/src/engine.tables.test.ts`.
  - Ran `npm run build && npm test` inside `adeu_isolated/node` and verified that all **428 tests passed** perfectly.

## Risk Assessment & Follow-ups
- **Risk:** Negligible. The fix extends JSON output structures by adding a standard backwards-compatible `"type"` metadata field and safely formats stderr console output.
- **Follow-ups:** Ensure any downstream dashboard tools or automated parsers consuming CLI stderr detailed outputs are aware of the newly introduced `"  Inserted row:"` and `"  Deleted row"` detailed lines.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description and Severity
- **Severity**: S3 (UX Enhancement)
- **Description**: When executing the `adeu apply` command with a structured batch json containing table row insertions (`insert_row`) and deletions (`delete_row`), the printed detailed report displays misleading information in the standard error stream. Specifically, it outputs `"New text: '<cells joined>'"` for a row insertion and an empty `"New text: ''"` for a row deletion. This makes it look as though simple text replacement or text clearing was performed, rather than the structural addition/removal of actual table rows, confusing users reviewing CLI execution reports.

### Minimal Reproduction
#### 1. Input Document (`doc_tables.docx`)
Create a Word document containing a single table:
- Row 1: `Row1 Col1`, `Row1 Col2`
- Row 2: `Row2 Col1`, `Row2 Col2`
- Row 3: `Row3 Col1`, `Row3 Col2`

#### 2. Edits JSON (`edits_tables.json`)
```json
[
  {
    "type": "insert_row",
    "target_text": "Row1 Col1 | Row1 Col2",
    "position": "below",
    "cells": ["NewRow Col1", "NewRow Col2"]
  },
  {
    "type": "delete_row",
    "target_text": "Row2 Col1"
  }
]
```

#### 3. Command
```bash
adeu apply -o doc_tables_applied.docx doc_tables.docx edits_tables.json
```

#### 4. Actual Behavior (misleading output printed to `sys.stderr`)
```
Detailed Edit Reports:
Edit 1 ✅ [applied]:
  Target: 'Row1 Col1 | Row1 Col2'
  New text: 'NewRow Col1 | NewRow Col2'
Edit 2 ✅ [applied]:
  Target: 'Row2 Col1'
  New text: ''
```

---

### Regression Test Code
The regression test has been added to `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py`:

```python
def test_detailed_report_table_modifications(tmp_path, capsys):
    """
    Test that the detailed report printed to sys.stderr by 'adeu apply'
    displays clear table operation indications ('Inserted row:' and 'Deleted row')
    for InsertTableRow and DeleteTableRow operations instead of misleading 'New text:' lines.
    """
    import json
    docx_path = tmp_path / "doc_tables.docx"
    edits_path = tmp_path / "edits_tables.json"
    out_path = tmp_path / "doc_tables_applied.docx"

    # 1. Create a document with a table
    doc = Document()
    doc.add_heading("Table Test", level=1)
    table = doc.add_table(rows=3, cols=2)
    table.cell(0, 0).text = "Row1 Col1"
    table.cell(0, 1).text = "Row1 Col2"
    table.cell(1, 0).text = "Row2 Col1"
    table.cell(1, 1).text = "Row2 Col2"
    table.cell(2, 0).text = "Row3 Col1"
    table.cell(2, 1).text = "Row3 Col2"
    doc.save(docx_path)

    # 2. Define our structural table edits
    edits = [
        {
            "type": "insert_row",
            "target_text": "Row1 Col1 | Row1 Col2",
            "position": "below",
            "cells": ["NewRow Col1", "NewRow Col2"]
        },
        {
            "type": "delete_row",
            "target_text": "Row2 Col1"
        }
    ]
    with open(edits_path, "w", encoding="utf-8") as f:
        json.dump(edits, f)

    # 3. Run adeu apply CLI
    rc = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(edits_path)])
    assert rc == 0

    # 4. Capture stderr output
    captured = capsys.readouterr()
    err_output = captured.err

    # Under the bug, it prints:
    #   New text: 'NewRow Col1 | NewRow Col2'
    # and
    #   New text: ''
    # When fixed, it should print:
    #   Inserted row: 'NewRow Col1 | NewRow Col2'
    # and
    #   Deleted row
    # without displaying "New text:" for these table operations.

    assert "Inserted row: 'NewRow Col1 | NewRow Col2'" in err_output
    assert "Deleted row" in err_output
    assert "New text:" not in err_output
```

---

### Pytest Failure Output
```
============================= test session starts ==============================
platform darwin -- Python 3.13.12, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.1.0, anyio-4.14.2, hypothesis-6.156.6
collected 913 items / 912 deselected / 1 selected

tests/test_cli_bug_repro.py F                                            [100%]

=================================== FAILURES ===================================
___________________ test_detailed_report_table_modifications ___________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-105/test_detailed_report_table_mod0')
capsys = <_pytest.capture.CaptureFixture object at 0x107f98ad0>

    def test_detailed_report_table_modifications(tmp_path, capsys):
        """
        Test that the detailed report printed to sys.stderr by 'adeu apply'
        displays clear table operation indications ('Inserted row:' and 'Deleted row')
        for InsertTableRow and DeleteTableRow operations instead of misleading 'New text:' lines.
        """
...
        # Under the bug, it prints:
        #   New text: 'NewRow Col1 | NewRow Col2'
        # and
        #   New text: ''
        # When fixed, it should print:
        #   Inserted row: 'NewRow Col1 | NewRow Col2'
        # and
        #   Deleted row
        # without displaying "New text:" for these table operations.
    
>       assert "Inserted row: 'NewRow Col1 | NewRow Col2'" in err_output
E       assert "Inserted row: 'NewRow Col1 | NewRow Col2'" in "Loading structured batch from /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-105/...l1 | Row1 Col2'\n  New text: 'NewRow Col1 | NewRow Col2'\nEdit 2 ✅ [applied]:\n  Target: 'Row2 Col1'\n  New text: ''\n"

tests/test_cli_bug_repro.py:325: AssertionError
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_detailed_report_table_modifications
====================== 1 failed, 912 deselected in 0.66s =======================
```

---

### Expected Behavior Once Fixed (Acceptance Criteria)
Once fixed:
1. When performing `insert_row`, the detailed report printed to standard error must output `"  Inserted row: '<cell contents>'"` instead of `"  New text: '<cell contents>'""`.
2. When performing `delete_row`, the detailed report printed to standard error must output `"  Deleted row"` instead of `"  New text: ''""`.
3. In both cases, the misleading label `"  New text:"` must not be shown for structural row table modifications.


</details>
