### PR TITLE
fix: Automated agentic CLI bug fix

### DIFF
--- a/python/src/adeu/ingest.py
+++ b/python/src/adeu/ingest.py
@@ -459,14 +459,24 @@ def build_paragraph_text(
                     # marker ("**A**" + " **B**" -> "**A B**"), mirroring the
                     # mapper's part-level elision exactly (QA 2026-07-19 F-03).
                     lead_match = re.match(r"(\s*)" + re.escape(new_style[0]), seg) if new_style != ("", "") else None
+                    trailing_ws = ""
+                    for char in reversed(pending_text):
+                        if char.isspace():
+                            trailing_ws = char + trailing_ws
+                        else:
+                            break
+                    pending_without_ws = pending_text if not trailing_ws else pending_text[: -len(trailing_ws)]
                     if (
                         new_style == current_style
                         and current_style != ("", "")
-                        and pending_text.endswith(current_style[1])
+                        and pending_without_ws.endswith(current_style[1])
                         and lead_match is not None
                     ):
                         pending_text = (
-                            pending_text[: -len(current_style[1])] + lead_match.group(1) + seg[lead_match.end() :]
+                            pending_without_ws[: -len(current_style[1])]
+                            + trailing_ws
+                            + lead_match.group(1)
+                            + seg[lead_match.end() :]
                         )
                     else:
                         pending_text += seg

--- a/python/src/adeu/redline/mapper.py
+++ b/python/src/adeu/redline/mapper.py
@@ -1180,6 +1180,16 @@ class DocumentMapper:
         return working_runs
 
     def get_insertion_anchor(self, index: int, rebuild_map: bool = True) -> Tuple[Optional[Run], Optional[Paragraph]]:
+        following_real = [s for s in self.spans if s.start == index and s.run is not None]
+        if following_real:
+            s_next = following_real[0]
+            next_run = s_next.run
+            if next_run is not None and s_next.run_offset > 0:
+                left, _ = self._split_run_at_index(next_run, s_next.run_offset)
+                if rebuild_map:
+                    self._build_map()
+                return left, s_next.paragraph
+
         preceding = [s for s in self.spans if s.end == index]
         if preceding:
             for s in reversed(preceding):

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -373,3 +373,55 @@ def test_cli_init_success_logs_stream_routing(tmp_path, capsys):
 
     # Assert that stderr is completely empty for successful run
     assert stderr_output == ""
+
+
+def test_start_of_run_insertion_alignment_repro(tmp_path, capsys):
+    """
+    Test that modifying the start of a styled run correctly places the insertion
+    at the start of the run (before the target text) instead of at the end of the run.
+    """
+    import json
+
+    docx_path = tmp_path / "simple.docx"
+    edits_path = tmp_path / "edits_modify.json"
+    out_path = tmp_path / "simple_edited.docx"
+
+    # 1. Create a pristine document simple.docx with some bold and italic text
+    doc = Document()
+    p = doc.add_paragraph("This is a simple paragraph with some plain text.")
+    p.add_run(" Bold text.").bold = True
+    p.add_run(" Italic text.").italic = True
+    doc.save(docx_path)
+
+    # 2. Create a JSON edit that prepends text to the bold section
+    edits = [{"type": "modify", "target_text": "Bold text.", "new_text": "Super Bold text."}]
+    with open(edits_path, "w", encoding="utf-8") as f:
+        json.dump(edits, f)
+
+    # 3. Apply the edit to a new document
+    rc_apply = _run_cli(["apply", str(docx_path), str(edits_path), "-o", str(out_path)])
+    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
+    assert out_path.exists(), "Applied output docx was not written"
+
+    # Clear capsys captured buffers
+    capsys.readouterr()
+
+    # 4. Extract the clean text output of the edited document
+    rc_extract = _run_cli(["extract", "--clean-view", str(out_path)])
+    assert rc_extract == 0, "CLI extract failed"
+
+    captured = capsys.readouterr()
+    stdout_output = captured.out
+
+    # Under the bug, the output contains:
+    # "This is a simple paragraph with some plain text. Bold text.Super  Italic text."
+    # When fixed, it should be:
+    # "This is a simple paragraph with some plain text. Super Bold text. Italic text."
+
+    # Assert that the text is correctly prepended, and "Bold text.Super" is NOT present.
+    assert "Super Bold text." in stdout_output, (
+        f"The insertion was incorrectly placed. Captured output:\n{stdout_output}"
+    )
+    assert "Bold text.Super" not in stdout_output, (
+        "The inserted text was appended to the end of the run instead of prepended."
+    )


### PR DESCRIPTION
## Agentic Auto-Fix

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[17:08:19] I will start by listing the directory structure of `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce` to verify the location of files and prepare to read the reports.
[17:08:21] I will read both `repro_report.md` and `eval_report.md` to understand the bug, how it was reproduced, and the expected behavior when fixed.
[17:08:23] I will now read `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/eval_report.md` to see what else was observed or context around the bug finding.
[17:08:26] I will run the verified failing test using `uv run pytest` from the `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python` directory to verify the failure locally.
[17:08:31] I will use `view_file` to inspect the reproduction test file `tests/test_cli_bug_repro.py` to see the full context of the failing test.
[17:08:35] I will list the contents of the `src/` directory to see the module/package structure of `adeu`.
[17:08:37] I will list files in `src/adeu` to find the modules implementing the core application logic (such as XML modification, document processing, CLI subcommands).
[17:08:39] I will list files inside `src/adeu/redline` where track-changes, applying edits, or similar features might live.
[17:08:42] I will search for occurrences of "w:ins" or "modify" or "insert" in `engine.py` using `grep_search` to find the logic responsible for applying modifications or edits to the document XML.
[17:08:44] I will run the grep search again with `MatchPerLine` enabled to locate the exact lines in `engine.py` containing "w:ins" so we can focus our code reading.
[17:08:47] I will view the `engine.py` file around line 3342 to inspect how `ModifyText` applies edits and how insertions are placed.
[17:08:49] I will view the next section of `engine.py` to see the logic for insertions and modifications.
[17:08:56] I will view the next lines of `engine.py` to see the logic for `EditOperationType.MODIFICATION`.
[17:09:10] I will search for `def track_delete_run` inside `engine.py` to see how it handles run deletion.
[17:09:17] I will view `engine.py` around line 1430 to understand how a run is marked as deleted during revision tracking.
[17:09:21] I will find the definition of `track_insert` using `grep_search`.
[17:09:23] I will view the `track_insert` function in `engine.py` from lines 810 to 880.
[17:09:28] I will view the next portion of `track_insert` (lines 881 to 1000) to see how individual runs or text portions are formatted inside the insertion tag.
[17:09:30] I will view lines 1001 to 1100 of `engine.py` to see the rest of the inline insertion logic in `track_insert`.
[17:09:32] I will search for `def _track_insert_inline` using `grep_search`.
[17:09:34] I will view the `_track_insert_inline` function (lines 1350 to 1391) to understand how inline inserts are styled and created.
[17:09:41] I will search for functions or logic related to splitting runs (like `split_run`) in `engine.py`.
[17:09:43] I will search for `split` in `engine.py` to find the exact mechanism for splitting text runs or elements.
[17:09:46] I will search for the definition of `find_target_runs_by_index` to see if/where run splitting occurs.
[17:09:49] I will view `mapper.py` starting around line 1105 to see how the XML runs are identified and potentially split during the mapping phase.
[17:09:51] I will view the next lines of `_resolve_runs_at_range` in `mapper.py` to see the rest of the splitting logic.
[17:10:07] I will search for the implementation of the `apply` command in `src/adeu/cli.py` to see what preprocessing or logic happens when applying edits.
[17:10:16] I will grep search for functions starting with `def ` in `src/adeu/cli.py` to understand its structure.
[17:10:50] I will view the `handle_apply` function in `src/adeu/cli.py` to see what happens when the `apply` subcommand is called.
[17:10:50] I will search for `_apply_single_edit_indexed` in `engine.py` to see the exact steps of applying an edit at a given index.
[17:10:50] I will view the `_apply_single_edit_indexed` method (lines 3301 to 3334) to see its arguments and setup logic.
[17:10:50] I will search for `def apply_edits` in `engine.py` to see how the list of edits is handled.
[17:10:50] I will view `engine.py` starting around line 2297 to see the implementation of `apply_edits`.
[17:10:50] I will search for `def _pre_resolve_heuristic_edit` in `engine.py` to see how edits are pre-resolved and potential sub-edits are created.
[17:10:50] I will view `_pre_resolve_heuristic_edit` starting at line 2815 to understand the pre-resolution and diff-splitting heuristic.
[17:10:50] I will search for `_resolve_single_match` to locate its definition and implementation in `engine.py`.
[17:10:50] I will view lines 3014 to 3110 of `engine.py` to understand the logic for resolving a single match.
[17:10:50] I will view lines 3111 to 3200 of `engine.py` to see the rest of `_resolve_single_match`.
[17:10:51] I will view lines 3201 to 3260 of `engine.py` to see how the single match resolution decides on the proxy edit or word diff sub-edits.
[17:10:53] I will view lines 3261 to 3300 of `engine.py` to see how the single match is completed and when the `_word_diff_sub_edits` is called.
[17:11:09] I will search for `_determine_style_source` in `engine.py` using `grep_search` to see how it decides which run's style to copy for the inserted text.
[17:11:20] I will view lines 3840 to 3880 of `engine.py` to see how `_determine_style_source` is implemented.
[17:11:28] I will list the function definitions in `src/adeu/ingest.py` to see the extraction logic.
[17:11:31] I will view the `build_paragraph_text` function in `src/adeu/ingest.py` to see how individual runs are combined, styled, and converted to markdown.
[17:11:33] I will view lines 451 to 520 of `src/adeu/ingest.py` to see the logic that decides when adjacent runs can merge and whether style markers are elided.
[17:11:37] I will search for `apply_formatting_to_segments` in `ingest.py`.
[17:11:40] I will search for `apply_formatting_to_segments` case-insensitively in `ingest.py`.
[17:11:42] I will search the python package for the definition of `apply_formatting_to_segments`.
[17:11:55] I will view `src/adeu/utils/docx.py` around line 669 to see `apply_formatting_to_segments`.
[17:13:37] I will view `src/adeu/ingest.py` around line 450 to get the exact contiguous block of code to replace.
[17:13:57] I will use `replace_file_content` to update the run-merging logic in `src/adeu/ingest.py` so that boundary whitespace does not prevent adjacent identical styles from merging.
[17:13:57] I will run the regression test now to see if our fix has resolved the failing assertion.
[17:13:57] I will run the full test suite to ensure that there are no regressions across the rest of the package.
[17:14:48] I will pause here and let the background test run complete. Once it finishes, I'll review the test results.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### The Bug and Severity
* **Severity**: S1 (Silently wrong output / layout corruption)
* **Description**: When applying edits to a Word document using `adeu apply`, modifications targeting the beginning of a styled (e.g., bold or italic) text run incorrectly append the insertion text *after* the styled run instead of prepending it *before* the target text. Although the dry-run CriticMarkup previews correctly output the intended text replacement order (i.e. `Super Bold text.`), the XML-level generator fails to split and position the `<w:ins>` tags before the target text run, resulting in scrambled sentences (such as `Bold text.Super`) and silent document layout/content corruption.

---

### Minimal Reproduction
Below are the minimal input structures, CLI commands, and results from the scratch experiment environment confirming the issue:

#### 1. Input Document (`simple.docx`):
Created via Python:
```python
import docx
doc = docx.Document()
p = doc.add_paragraph("This is a simple paragraph with some plain text.")
p.add_run(" Bold text.").bold = True
p.add_run(" Italic text.").italic = True
doc.save("simple.docx")
```

#### 2. Edit Instructions (`edits_modify.json`):
```json
[
  {
    "type": "modify",
    "target_text": "Bold text.",
    "new_text": "Super Bold text."
  }
]
```

#### 3. Execution Commands:
```bash
# Apply the edits
adeu apply simple.docx edits_modify.json -o simple_edited.docx

# Extract and view the clean result
adeu extract --clean-view simple_edited.docx
```

#### 4. Actual Incorrect Output:
```
This is a simple paragraph with some plain text. **Bold text.**Super  _Italic text._
```
The inserted text `"Super "` was placed *after* the bold run `"Bold text."` rather than *before* it.

---

### Regression Test Code
The regression test has been successfully integrated into the existing test suite in `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py`:

```python
def test_start_of_run_insertion_alignment_repro(tmp_path, capsys):
    """
    Test that modifying the start of a styled run correctly places the insertion
    at the start of the run (before the target text) instead of at the end of the run.
    """
    import json

    docx_path = tmp_path / "simple.docx"
    edits_path = tmp_path / "edits_modify.json"
    out_path = tmp_path / "simple_edited.docx"

    # 1. Create a pristine document simple.docx with some bold and italic text
    doc = Document()
    p = doc.add_paragraph("This is a simple paragraph with some plain text.")
    p.add_run(" Bold text.").bold = True
    p.add_run(" Italic text.").italic = True
    doc.save(docx_path)

    # 2. Create a JSON edit that prepends text to the bold section
    edits = [
        {
            "type": "modify",
            "target_text": "Bold text.",
            "new_text": "Super Bold text."
        }
    ]
    with open(edits_path, "w", encoding="utf-8") as f:
        json.dump(edits, f)

    # 3. Apply the edit to a new document
    rc_apply = _run_cli(["apply", str(docx_path), str(edits_path), "-o", str(out_path)])
    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
    assert out_path.exists(), "Applied output docx was not written"

    # Clear capsys captured buffers
    capsys.readouterr()

    # 4. Extract the clean text output of the edited document
    rc_extract = _run_cli(["extract", "--clean-view", str(out_path)])
    assert rc_extract == 0, "CLI extract failed"

    captured = capsys.readouterr()
    stdout_output = captured.out

    # Under the bug, the output contains:
    # "This is a simple paragraph with some plain text. Bold text.Super  Italic text."
    # When fixed, it should be:
    # "This is a simple paragraph with some plain text. Super Bold text. Italic text."
    
    # Assert that the text is correctly prepended, and "Bold text.Super" is NOT present.
    assert "Super Bold text." in stdout_output, (
        f"The insertion was incorrectly placed. Captured output:\n{stdout_output}"
    )
    assert "Bold text.Super" not in stdout_output, (
        "The inserted text was appended to the end of the run instead of prepended."
    )
```

---

### Pytest Failure Output
Running `uv run pytest tests/test_cli_bug_repro.py -k test_start_of_run_insertion_alignment_repro` produces the following deterministic failure:

```
=================================== FAILURES ===================================
_________________ test_start_of_run_insertion_alignment_repro __________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-133/test_start_of_run_insertion_al0')
capsys = <_pytest.capture.CaptureFixture object at 0x10aeff230>

    def test_start_of_run_insertion_alignment_repro(tmp_path, capsys):
        """
        Test that modifying the start of a styled run correctly places the insertion
        at the start of the run (before the target text) instead of at the end of the run.
        """
        import json
    
        docx_path = tmp_path / "simple.docx"
        edits_path = tmp_path / "edits_modify.json"
        out_path = tmp_path / "simple_edited.docx"
    
        # 1. Create a pristine document simple.docx with some bold and italic text
        doc = Document()
        p = doc.add_paragraph("This is a simple paragraph with some plain text.")
        p.add_run(" Bold text.").bold = True
        p.add_run(" Italic text.").italic = True
        doc.save(docx_path)
    
        # 2. Create a JSON edit that prepends text to the bold section
        edits = [
            {
                "type": "modify",
                "target_text": "Bold text.",
                "new_text": "Super Bold text."
            }
        ]
        with open(edits_path, "w", encoding="utf-8") as f:
            json.dump(edits, f)
    
        # 3. Apply the edit to a new document
        rc_apply = _run_cli(["apply", str(docx_path), str(edits_path), "-o", str(out_path)])
        assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
        assert out_path.exists(), "Applied output docx was not written"
    
        # Clear capsys captured buffers
        capsys.readouterr()
    
        # 4. Extract the clean text output of the edited document
        rc_extract = _run_cli(["extract", "--clean-view", str(out_path)])
        assert rc_extract == 0, "CLI extract failed"
    
        captured = capsys.readouterr()
        stdout_output = captured.out
    
        # Under the bug, the output contains:
        # "This is a simple paragraph with some plain text. Bold text.Super  Italic text."
        # When fixed, it should be:
        # "This is a simple paragraph with some plain text. Super Bold text. Italic text."
    
        # Assert that the text is correctly prepended, and "Bold text.Super" is NOT present.
>       assert "Super Bold text." in stdout_output, (
            f"The insertion was incorrectly placed. Captured output:\n{stdout_output}"
        )
E       AssertionError: The insertion was incorrectly placed. Captured output:
E         > **File Path:** `/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-133/test_start_of_run_insertion_al0/simple_edited.docx`
E         
E         This is a simple paragraph with some plain text. **Bold text.**Super  _Italic text._
E         
E       assert 'Super Bold text.' in '> **File Path:** `/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-133/test_start_o...tion_al0/simple_edited.docx`\n\nThis is a simple paragraph with some plain text. **Bold text.**Super  _Italic text._\n'

tests/test_cli_bug_repro.py:428: AssertionError
```

---

### Expected Behavior Once Fixed (Acceptance Criteria)
1. When applying a modification edit that prepends text to a styled run, the XML-level block/run split generator must correctly split the target run or prepend the inserted `<w:ins>` tags so that the newly inserted text is positioned *before* the target text run in the output document.
2. The clean-text output of the applied document must show the modification correctly placed at the beginning of the styled run:
   `This is a simple paragraph with some plain text. Super Bold text. Italic text.`
3. No silent text layout corruption, misaligned formatting, or reversed insertions should remain in the output `.docx` file.


</details>
