### PR TITLE
fix: Automated agentic CLI (adeu) bug fix

### DIFF
--- a/python/src/adeu/redline/mapper.py
+++ b/python/src/adeu/redline/mapper.py
@@ -6,7 +6,6 @@ from typing import Any, List, Optional, Tuple
 
 import structlog
 from docx.document import Document as DocumentObject
-from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.table import Table
 from docx.text.paragraph import Paragraph
@@ -1254,17 +1253,9 @@ class DocumentMapper:
 
         run.text = left_text
         new_r_element = deepcopy(run._element)
-        t_list = new_r_element.findall(qn("w:t"))
-        for t in t_list:
-            new_r_element.remove(t)
-
-        new_t = OxmlElement("w:t")
-        new_t.text = right_text
-        if right_text.strip() != right_text:
-            new_t.set(qn("xml:space"), "preserve")
-        new_r_element.append(new_t)
         run._element.addnext(new_r_element)
         new_run = Run(new_r_element, run._parent)
+        new_run.text = right_text
         return run, new_run
 
     def get_context_at_range(self, start_idx: int, end_idx: int) -> Optional[TextSpan]:

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -425,3 +425,50 @@ def test_start_of_run_insertion_alignment_repro(tmp_path, capsys):
     assert "Bold text.Super" not in stdout_output, (
         "The inserted text was appended to the end of the run instead of prepended."
     )
+
+
+def test_apply_unicode_character_offset_drift_repro(tmp_path):
+    """
+    Test that adeu apply successfully applies text-file edits to a document containing
+    multi-byte unicode characters (Chinese, Cyrillic, Japanese, Finnish, Emojis)
+    without character-to-byte offset drift that causes text corruption and fails
+    post-apply verification.
+    """
+    docx_path = tmp_path / "doc_unicode.docx"
+    txt_path = tmp_path / "modified_unicode.txt"
+    out_path = tmp_path / "unicode_applied.docx"
+
+    # 1. Create the unicode document
+    doc = Document()
+    doc.add_heading("Unicode and Internationalization Test", level=0)
+    p = doc.add_paragraph("This paragraph contains unicode characters from various languages:")
+    p.add_run("\nChinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！")
+    p.add_run("\nCyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.")
+    p.add_run("\nJapanese: 素早い茶色の狐が怠惰な犬を飛び越えます。")
+    p.add_run("\nFinnish: Vihreä kissa käveli liukkaalla jäällä ja lauloi iloisesti.")
+    p.add_run("\nEmojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠")
+    doc.save(docx_path)
+
+    # 2. Create the modified text file
+    modified_content = f"""> **File Path:** `{docx_path.name}`
+
+# Unicode and Internationalization Test
+
+This paragraph contains unicode characters from various languages:
+Chinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！ 🎉 (Wow!)
+Cyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.
+Japanese: 素早い茶色の狐が怠惰な犬を飛び越えます。
+Finnish: Keltainen kissa käveli liukkaalla jäällä ja lauloi iloisesti.
+Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟
+"""
+
+    txt_path.write_text(modified_content, encoding="utf-8")
+
+    # 3. Run adeu apply CLI
+    rc_apply = _run_cli(["apply", str(docx_path), str(txt_path), "-o", str(out_path)])
+
+    # Under the bug, apply fails (returns exit code 1) because of character/byte offset drift
+    # which leads to verification mismatch.
+    # When fixed, it should succeed (return 0) and write out the file.
+    assert rc_apply == 0, "adeu apply failed due to unicode character-to-byte offset drift"
+    assert out_path.exists(), "Applied output docx was not written"


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[21:16:09] I will start by listing the contents of the workspace directory `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce` to understand the files and structure.
[21:16:11] I will view the `repro_report.md` file to understand the reproduction steps and expectations.
[21:16:14] I will read the `eval_report.md` file to see what other details and context it might provide about the bug.
[21:16:17] I will run the failing test using `uv run pytest` to confirm the reproduction.
[21:16:20] I will use grep search to locate the failing test in `tests/test_cli_bug_repro.py`.
[21:16:24] I will run a grep search for the test definition inside `tests/test_cli_bug_repro.py` to get the line numbers.
[21:16:26] I will view the test file around line 430 to inspect the test implementation.
[21:16:28] I will list the directory `src/` under `python` to understand the packages and modules structure.
[21:16:30] I will list the contents of the `src/adeu` package.
[21:16:32] I will list the contents of the `src/adeu/redline` directory.
[21:16:33] I will search the codebase for the string "Post-apply verification failed" to pinpoint the verification and apply logic.
[21:16:36] I will search for "Calculating diff from text file" to locate where the text file apply logic begins in the CLI.
[21:16:38] I will view `src/adeu/cli.py` around lines 1000 to 1100.
[21:16:44] I will view the remaining part of `src/adeu/cli.py` related to the apply verification logic (lines 1100 to 1170).
[21:16:46] I will search for `generate_edits_via_paragraph_alignment` inside `src/adeu/diff.py` to see how text differences are aligned.
[21:16:48] I will view `src/adeu/diff.py` starting around line 1117 to examine the `generate_edits_via_paragraph_alignment` function.
[21:16:50] I will search for `generate_edits_from_text` to understand where and how word-level differences are computed.
[21:16:53] I will view `src/adeu/diff.py` around line 220 to examine `generate_edits_from_text`.
[21:16:54] I will view the rest of the `generate_edits_from_text` function.
[21:16:59] I will search the codebase for `_match_start_index` to find how these offsets are processed.
[21:17:05] I will search for occurrences of `.encode` or `utf` in `src/adeu/redline` to see if byte-lengths or specific encodings are used in the engine.
[21:17:16] I will search for `utf-16` or `utf16` in the codebase to see if Word XML or other elements use UTF-16 representation (which is typical for Word/Windows APIs or .NET/Java-style string lengths).
[21:17:21] I will view the code in `src/adeu/redline/engine.py` around line 2155.
[21:17:23] I will view lines 2300 to 2390 in `src/adeu/redline/engine.py` to see the logic of resolving and applying these pinned/unpinned edits.
[21:17:28] I will search for the definition of `DocumentMapper` class to understand how the document text is represented and mapped.
[21:17:31] I will view the definition and initial methods of the `DocumentMapper` class in `src/adeu/redline/mapper.py` starting around line 216.
[21:17:34] I will view the next block of lines in `src/adeu/redline/mapper.py` (lines 301 to 380).
[21:17:38] I will search for `_extract_text_from_doc` definition in `src/adeu/ingest.py` to see how text is extracted from a DOCX document.
[21:17:43] I will view the definition of `_extract_text_from_doc` in `src/adeu/ingest.py` around line 97.
[21:17:45] I will view lines 141 to 210 in `src/adeu/ingest.py` to see how `_extract_text_from_doc` processes the document parts and extracts text.
[21:17:49] I will view the next block of lines in `src/adeu/ingest.py` to trace block extraction and paragraph content building.
[21:17:51] I will search for the definition of `build_paragraph_text` in `src/adeu/ingest.py`.
[21:17:53] I will view the `build_paragraph_text` function in `src/adeu/ingest.py`.
[21:18:05] I will run a quick Python diagnostic command using `uv run python` to print out the extracted original text and the calculated paragraph-aligned edits along with their `_match_start_index`.
[21:18:24] I will print slices of `text_orig` around indices 147, 257, and 334 to see if they match the targets exactly in character-based indexing.
[21:18:24] I will search for occurrences of `self.spans` in `src/adeu/redline/mapper.py` to see how text spans and their offsets are managed.
[21:18:24] I will search for `class TextSpan` to see its attributes and definition.
[21:18:24] I will view the definition of `TextSpan` in `src/adeu/redline/mapper.py`.
[21:18:29] I will search for functions starting with `_add_` in `src/adeu/redline/mapper.py` to see how text segments (real or virtual) are mapped to spans.
[21:18:31] I will view the `_add_virtual_text` function and any neighboring functions in `src/adeu/redline/mapper.py` starting around line 814.
[21:18:34] I will search for `_map_paragraph_content` to see how real run text is mapped into spans.
[21:18:36] I will view `_map_paragraph_content` in `src/adeu/redline/mapper.py` starting around line 443.
[21:18:44] I will search for `def process_batch` in `src/adeu/redline/engine.py` to trace how batch edits are applied.
[21:18:52] I will view `src/adeu/redline/engine.py` around line 2070.
[21:18:55] I will view lines 2176 to 2260 in `src/adeu/redline/engine.py`.
[21:18:57] I will search for `def apply_edits` inside `src/adeu/redline/engine.py`.
[21:19:02] I will view the `apply_edits` function in `src/adeu/redline/engine.py`.
[21:19:04] I will view lines 2391 to 2470 of `src/adeu/redline/engine.py` to see how the resolved edits are ordered and applied.
[21:19:08] I will view lines 2471 to 2510 in `src/adeu/redline/engine.py`.
[21:19:11] I will search for `_apply_single_edit_indexed` definition in `src/adeu/redline/engine.py`.
[21:19:13] I will view the `_apply_single_edit_indexed` method in `src/adeu/redline/engine.py` starting around line 3301.
[21:19:15] I will view lines 3361 to 3450 in `src/adeu/redline/engine.py`.
[21:19:17] I will view lines 3451 to 3550 of `src/adeu/redline/engine.py`.
[21:19:20] I will view lines 3551 to 3650 of `src/adeu/redline/engine.py`.
[21:19:23] I will search for `find_target_runs_by_index` inside `src/adeu/redline/mapper.py` to see how target runs are found by start index and length.
[21:19:26] I will view `find_target_runs_by_index` in `src/adeu/redline/mapper.py` starting around line 1105.
[21:19:28] I will view lines 1151 to 1230 in `src/adeu/redline/mapper.py` to see the logic of `_resolve_runs_at_range` and run splitting.
[21:19:32] I will search for `_split_run_at_index` in `src/adeu/redline/mapper.py`.
[21:19:34] I will view the `_split_run_at_index` method in `src/adeu/redline/mapper.py`.
[21:19:38] I will search for `_load_roundtrip_text` in `src/adeu/cli.py` to see how it reads the modified roundtrip text.
[21:19:43] I will view `_load_roundtrip_text` in `src/adeu/cli.py` starting around line 410.
[21:19:47] I will search for `_strip_page_chrome` definition.
[21:19:54] I will view `_strip_page_chrome` starting around line 387.
[21:19:59] I will view the rest of the `_read_text_file` method.
[21:20:06] I will run a python diagnostic script to calculate and compare character-based vs byte-based/word-based metrics for the text up to `Vihreä` to see what might have caused the 9-character drift.
[21:20:13] I will run a python diagnostic script to build the `DocumentMapper` on the generated document and call `find_target_runs_by_index(257, 6)` to see which runs it returns and what their contents are.
[21:20:22] I will print all spans in `mapper.spans` to see the mapping of character indexes to physical text and runs.
[21:20:31] I will view `_map_paragraph_content` from line 521 to 600 in `src/adeu/redline/mapper.py` to see how span ranges and lengths are calculated for runs.
[21:20:38] I will search for `get_run_text` definition in the codebase.
[21:20:44] I will view the `get_run_text` function in `src/adeu/utils/docx.py`.
[21:20:52] I will run a python command to inspect Span 6's run details: length of the span text, length of the raw `run.text` property, and length of `get_run_text(run)`.
[21:20:59] I will run a python command to see exactly what characters are at indices `[257:257+10]` in `mapper.full_text`.
[21:21:24] I will run a python diagnostic script to step through `find_target_runs_by_index(257, 6)` on the mapper and print internal variables at each step to see exactly why it resolves to `['\nVihre']`.
[21:21:43] I will run a python diagnostic script to execute `_resolve_runs_at_range(257, 263)` step-by-step and print `working_runs` at the very end.
[21:21:43] I will run a python diagnostic script to execute `find_target_runs_by_index(257, 6)` and print out the values of `first_real_span.start`, `first_real_span.run_offset`, `local_start`, and more, directly inside the method.
[21:21:50] I will run a python diagnostic script to check if python-docx `run.text` ignores `<w:br/>` (which we added via `\n` in `add_run`), making it shorter than `get_run_text(run)`.
[21:21:59] I will run a python command to print the exact list of characters and lengths of `run.text` to see if there are any hidden characters or if length matches our expectations.
[21:22:05] I will run a python diagnostic script to call `_split_run_at_index` and print the exact values of `text`, `split_index`, `left_text`, and `right_text` inside the method.
[21:22:14] I will run a python diagnostic script to print the XML elements of the run before and after splitting to confirm that any `<w:br/>`, `<w:tab/>`, or `<w:cr/>` elements are indeed duplicated or left behind in the right-hand split run.
[21:22:28] I will view `tests/test_cli_bug_repro.py` to see what test cases and assertions it has.
[21:22:31] I will view lines 101 to 300 of `tests/test_cli_bug_repro.py`.
[21:22:38] I will view the rest of `tests/test_cli_bug_repro.py` starting at line 301.
[21:22:41] I will run the regression test suite for `test_apply_unicode_character_offset_drift_repro` to verify it reproduces the character-to-byte offset drift failure exactly.
[21:22:55] I will run a python diagnostic script to test if assigning `new_run.text = right_text` on a deepcopied run element correctly preserves formatting and accurately sets the right-hand split text without duplicating `<w:br/>`.
[21:23:11] I will search for any other occurrences of `_split_run_at_index` in the repository to make sure we cover all of them.
[21:23:19] I will replace the implementation of `_split_run_at_index` in `src/adeu/redline/mapper.py` using `replace_file_content` to correctly set the right run's text using the standard setter, which avoids duplicating any `<w:br/>` elements and prevents offset drift.
[21:23:21] I will run the regression test `test_apply_unicode_character_offset_drift_repro` again to check if our fix resolves the offset drift issue.
[21:23:24] I will run the entire `tests/test_cli_bug_repro.py` test suite to verify that all of the reproducer tests pass with this fix.
[21:23:29] I will list the contents of the `tests` directory to see all test files.
[21:23:35] I will run the entire test suite to ensure that no existing functionality is broken by our change.
[21:24:27] I will stop calling tools and wait for the test suite execution to complete in the background.
[21:24:30] I have successfully identified and fixed the root cause of the character-to-byte offset drift when applying edits to documents containing multi-byte Unicode characters.
[21:24:30] 
[21:24:30] ### Analysis & Cause of the Bug
[21:24:30] During `_split_run_at_index` in `src/adeu/redline/mapper.py`, the run splitting logic was mutated as follows:
[21:24:30] 1. `run.text = left_text` was assigned first. Under the hood, python-docx cleared all elements of the run, converting any newlines (`\n`) in `left_text` into `<w:br/>` elements and text into `<w:t>`.
[21:24:30] 2. A duplicate of the mutated run element was created using `deepcopy(run._element)`.
[21:24:31] 3. The splitting logic attempted to manually reconstruct the text elements of the right-hand split run by finding and removing only `w:t` elements inside `new_r_element` and appending a newly created `<w:t>` with `right_text`.
[21:24:31] 4. However, because `<w:br/>` elements were not removed from `new_r_element`, any line breaks corresponding to `\n` in `left_text` (such as `\n` in `\nFinnish: Vihreä`) were duplicated into the right-hand split run. This caused the right run text to start with an unexpected `\n`, shifting all subsequent character offsets and leading to an accumulating character/byte drift as the document was edited sequentially backwards.
[21:24:31] 
[21:24:31] ### Solution
[21:24:31] Instead of manually manipulating the XML elements in the duplicated right run to insert the split text, we now invoke the standard `Run.text` setter property in python-docx:
[21:24:31] ```python
[21:24:32]     def _split_run_at_index(self, run: Run, split_index: int) -> Tuple[Run, Run]:
[21:24:32]         text = run.text
[21:24:32]         left_text = text[:split_index]
[21:24:32]         right_text = text[split_index:]
[21:24:32] 
[21:24:32]         run.text = left_text
[21:24:32]         new_r_element = deepcopy(run._element)
[21:24:32]         run._element.addnext(new_r_element)
[21:24:32]         new_run = Run(new_r_element, run._parent)
[21:24:32]         new_run.text = right_text
[21:24:32]         return run, new_run
[21:24:32] ```
[21:24:32] By setting `new_run.text = right_text`, python-docx's setter automatically and correctly clears the existing content (including any `<w:br/>` elements that were duplicated during deepcopy) and populates the text correctly, matching the behavior of the left run.
[21:24:32] 
[21:24:32] ### Verification
[21:24:32] - Ran the specific regression test case `test_apply_unicode_character_offset_drift_repro` which successfully passed.
[21:24:33] - Ran the complete test suite (916 tests across 100 test files) and verified that all 878 non-skipped tests passed without any regressions.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
* **Severity:** S1 (Wrong output / data corruption / failing post-verification checks)
* **Description:** When using the text-based apply command (`adeu apply original.docx modified_text.txt`) on a document containing non-ASCII multi-byte unicode characters (such as Emojis, Chinese, Cyrillic, or Japanese), the internal offsets of changes drift. The drift accumulates as we go deeper into the text, causing `adeu` to delete or modify the wrong characters, which results in text corruption and fails post-apply verification checks.

### Minimal Reproduction
1. Programmatically generate a document containing multi-byte characters and a modified text file in scratch space using Python:
```python
import docx
from docx import Document

# 1. Create the unicode document
doc = Document()
doc.add_heading("Unicode and Internationalization Test", level=0)
p = doc.add_paragraph("This paragraph contains unicode characters from various languages:")
p.add_run("\nChinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！")
p.add_run("\nCyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.")
p.add_run("\nJapanese: 素早い茶色の狐が怠惰な犬を飛び越えます。")
p.add_run("\nFinnish: Vihreä kissa käveli liukkaalla jäällä ja lauloi iloisesti.")
p.add_run("\nEmojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠")
doc.save("doc_unicode.docx")

# 2. Create the modified text file
modified_content = """> **File Path:** `doc_unicode.docx`

# Unicode and Internationalization Test

This paragraph contains unicode characters from various languages:
Chinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！ 🎉 (Wow!)
Cyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.
Japanese: 素早い茶色の狐が怠惰な犬を飛び越えます。
Finnish: Keltainen kissa käveli liukkaalla jäällä ja lauloi iloisesti.
Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟
"""

with open("modified_unicode.txt", "w", encoding="utf-8") as f:
    f.write(modified_content)
```

2. Run the reproduction command:
```bash
adeu apply doc_unicode.docx modified_unicode.txt -o unicode_applied.docx
```

* **Actual Result:** The command exits with status code 1 and fails post-apply verification due to character/byte offset drift that corrupts the text boundaries.

### Full Test Code
```python
def test_apply_unicode_character_offset_drift_repro(tmp_path):
    """
    Test that adeu apply successfully applies text-file edits to a document containing
    multi-byte unicode characters (Chinese, Cyrillic, Japanese, Finnish, Emojis)
    without character-to-byte offset drift that causes text corruption and fails
    post-apply verification.
    """
    docx_path = tmp_path / "doc_unicode.docx"
    txt_path = tmp_path / "modified_unicode.txt"
    out_path = tmp_path / "unicode_applied.docx"

    # 1. Create the unicode document
    doc = Document()
    doc.add_heading("Unicode and Internationalization Test", level=0)
    p = doc.add_paragraph("This paragraph contains unicode characters from various languages:")
    p.add_run("\nChinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！")
    p.add_run("\nCyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.")
    p.add_run("\nJapanese: 素早い茶色の狐が怠惰な犬を飛び越えます。")
    p.add_run("\nFinnish: Vihreä kissa käveli liukkaalla jäällä ja lauloi iloisesti.")
    p.add_run("\nEmojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠")
    doc.save(docx_path)

    # 2. Create the modified text file
    modified_content = f"""> **File Path:** `{docx_path.name}`

# Unicode and Internationalization Test

This paragraph contains unicode characters from various languages:
Chinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！ 🎉 (Wow!)
Cyrillic (Russian): Быстрая бурая лиса прыгает SQL через ленивую собаку.
Japanese: 素早い茶色の狐が怠惰な犬を飛び越えます。
Finnish: Keltainen kissa käveli liukkaalla jäällä ja lauloi iloisesti.
Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟
"""

    txt_path.write_text(modified_content, encoding="utf-8")

    # 3. Run adeu apply CLI
    rc_apply = _run_cli(["apply", str(docx_path), str(txt_path), "-o", str(out_path)])

    # Under the bug, apply fails (returns exit code 1) because of character/byte offset drift
    # which leads to verification mismatch.
    # When fixed, it should succeed (return 0) and write out the file.
    assert rc_apply == 0, "adeu apply failed due to unicode character-to-byte offset drift"
    assert out_path.exists(), "Applied output docx was not written"
```

### Pytest Failure Output
```
=================================== FAILURES ===================================
_______________ test_apply_unicode_character_offset_drift_repro ________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0')

    def test_apply_unicode_character_offset_drift_repro(tmp_path):
        """
        Test that adeu apply successfully applies text-file edits to a document containing
        multi-byte unicode characters (Chinese, Cyrillic, Japanese, Finnish, Emojis)
        without character-to-byte offset drift that causes text corruption and fails
        post-apply verification.
        """
        docx_path = tmp_path / "doc_unicode.docx"
        txt_path = tmp_path / "modified_unicode.txt"
        out_path = tmp_path / "unicode_applied.docx"
    
        # 1. Create the unicode document
        doc = Document()
        doc.add_heading("Unicode and Internationalization Test", level=0)
        p = doc.add_paragraph("This paragraph contains unicode characters from various languages:")
        p.add_run("\nChinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！")
        p.add_run("\nCyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.")
        p.add_run("\nJapanese: 素早い茶色の狐が怠惰な犬を飛び越えます。")
        p.add_run("\nFinnish: Vihreä kissa käveli liukkaalla jäällä ja lauloi iloisesti.")
        p.add_run("\nEmojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠")
        doc.save(docx_path)
    
        # 2. Create the modified text file
        modified_content = f"""> **File Path:** `{docx_path.name}`
    
    # Unicode and Internationalization Test
    
    This paragraph contains unicode characters from various languages:
    Chinese (Simplified): 🚀 欢迎使用 Adeu 红线引擎！ 🎉 (Wow!)
    Cyrillic (Russian): Быстрая бурая лиса прыгает через ленивую собаку.
    Japanese: 素早い茶色の狐が怠惰な犬を飛び越えます。
    Finnish: Keltainen kissa käveli liukkaalla jäällä ja lauloi iloisesti.
    Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟
    """
    
        txt_path.write_text(modified_content, encoding="utf-8")
    
        # 3. Run adeu apply CLI
        rc_apply = _run_cli(["apply", str(docx_path), str(txt_path), "-o", str(out_path)])
    
        # Under the bug, apply fails (returns exit code 1) because of character/byte offset drift
        # which leads to verification mismatch.
        # When fixed, it should succeed (return 0) and write out the file.
>       assert rc_apply == 0, "adeu apply failed due to unicode character-to-byte offset drift"
E       AssertionError: adeu apply failed due to unicode character-to-byte offset drift
E       assert 1 == 0

tests/test_cli_bug_repro.py:473: AssertionError
----------------------------- Captured stderr call -----------------------------
Calculating diff from text file /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0/modified_unicode.txt...
Applying 3 changes to doc_unicode.docx...
❌ Verification failed — no output was written to: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0/unicode_applied.docx
   A diagnostic copy (NOT the requested document) was kept at: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0/unicode_applied.unverified.docx
Actions: 0 applied, 0 skipped.
Edits: 3 applied, 0 skipped.

Detailed Edit Reports:
Edit 1 ✅ [applied]:
  Target: ''
  New text: ' 🎉 (Wow!)'
  Preview (CriticMarkup): Simplified): 🚀 欢迎使用 Adeu 红线引擎！{----}{++ 🎉 (Wow!)++}
Cyrillic (Russian): Быстрая б
  Clean text preview: Simplified): 🚀 欢迎使用 Adeu 红线引擎！ 🎉 (Wow!)
Cyrillic (Russian): Быстрая б
Edit 2 ✅ [applied]:
  Target: 'Vihreä'
  New text: 'Keltainen'
  Preview (CriticMarkup): 素早い茶色の狐が怠惰な犬を飛び越えます。
Finnish: {--Vihreä--}{++Keltainen++} kissa käveli liukkaalla jääll
  Clean text preview: 素早い茶色の狐が怠惰な犬を飛び越えます。
Finnish: Keltainen kissa käveli liukkaalla jääll
Edit 3 ✅ [applied]:
  Target: ''
  New text: ' ✨🌟
'
  Preview (CriticMarkup):  iloisesti.
Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠{----}{++ ✨🌟
++}
  Clean text preview:  iloisesti.
Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟


❌ Post-apply verification failed: the applied document's clean text does not match the supplied text (first divergence at character 275: applied reads '\nä kissa käveli liukkaalla jäällä ja lau', supplied text reads ' kissa käveli liukkaalla jäällä ja laulo'). The document structure could not fully realize the requested text (e.g. headings or table cells cannot be deleted via text replacement). Nothing was written to '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0/unicode_applied.docx'; a diagnostic copy was kept at '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-151/test_apply_unicode_character_o0/unicode_applied.unverified.docx' — it is NOT the requested document.
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_apply_unicode_character_offset_drift_repro
```

### Expected Behavior Once Fixed (Acceptance Criterion)
`adeu apply` should correctly align and apply diff ranges even when the original document contains multi-byte unicode characters. The internal tracking algorithm must correctly use character-based offsets (instead of byte-based counts/offsets) when performing slices, matching, or replacing portions of text. When fixed, `adeu apply` should successfully write out the final `unicode_applied.docx` (with correct track changes: `Vihreä` replaced by `Keltainen`) and exit with status `0`.


</details>
