### PR TITLE
fix: normalize trailing whitespace in text-file diff alignment

### DIFF
--- a/node/packages/core/src/diff.test.ts
+++ b/node/packages/core/src/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { trim_common_context, generate_edits_from_text, create_word_patch_diff } from './diff.js';
+import { trim_common_context, generate_edits_from_text, create_word_patch_diff, generate_edits_via_paragraph_alignment } from './diff.js';
 
 describe('Diff Logic & Context Trimming', () => {
   it('handles basic prefix and suffix', () => {
@@ -70,5 +70,12 @@ describe('Diff Logic & Context Trimming', () => {
     expect(diff).toContain("- Company");
     expect(diff).toContain("+ Corporation");
     expect(diff).toContain(" This agreement is made between the"); // Within 40-char context window so no truncation
+  });
+
+  it('handles trailing newline and whitespace safely in paragraph alignment', () => {
+    const original = "This is a single paragraph of the draft.";
+    const modified = "This is a single paragraph of the draft.\n";
+    const edits = generate_edits_via_paragraph_alignment(original, modified);
+    expect(edits.length).toBe(0);
   });
 });

--- a/node/packages/core/src/diff.ts
+++ b/node/packages/core/src/diff.ts
@@ -544,6 +544,12 @@ export function generate_edits_via_paragraph_alignment(
   original_text: string,
   modified_text: string,
 ): ModifyText[] {
+  // Normalize trailing whitespace/newlines in modified_text to match original_text
+  const orig_stripped = original_text.trimEnd();
+  const orig_ws = original_text.slice(orig_stripped.length);
+  const mod_stripped = modified_text.trimEnd();
+  modified_text = mod_stripped + orig_ws;
+
   const orig_paragraphs = original_text.split("\n\n");
   const mod_paragraphs = modified_text.split("\n\n");
 

--- a/python/src/adeu/diff.py
+++ b/python/src/adeu/diff.py
@@ -1122,6 +1122,12 @@ def generate_edits_via_paragraph_alignment(original_text: str, modified_text: st
     """
     import difflib
 
+    # Normalize trailing whitespace/newlines in modified_text to match original_text
+    orig_stripped = original_text.rstrip()
+    orig_ws = original_text[len(orig_stripped) :]
+    mod_stripped = modified_text.rstrip()
+    modified_text = mod_stripped + orig_ws
+
     orig_paragraphs = original_text.split("\n\n")
     mod_paragraphs = modified_text.split("\n\n")
 

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -472,3 +472,102 @@ Emojis: 🍕🌮🍣🍺🎈🎉🔥💧🌲🧠 ✨🌟
     # When fixed, it should succeed (return 0) and write out the file.
     assert rc_apply == 0, "adeu apply failed due to unicode character-to-byte offset drift"
     assert out_path.exists(), "Applied output docx was not written"
+
+
+def test_apply_trailing_newline_repro(tmp_path, capsys):
+    """
+    Test that adeu diff and adeu apply correctly handle an accidental trailing newline
+    appended to the extracted text file (e.g. by a standard text editor on save).
+    Under the bug, the diff engine computes the trailing newline as a substantive insertion/change
+    and reports/applies it.
+    When fixed, the diff engine should detect and strip trailing blank lines or trailing whitespace
+    from the plain text file, and should not compute or apply any edits, resulting in 0 changes.
+    """
+    docx_path = tmp_path / "initial.docx"
+    txt_path = tmp_path / "extracted.txt"
+    out_path = tmp_path / "result.docx"
+
+    # 1. Create original docx with a single paragraph
+    doc = Document()
+    doc.add_paragraph("This is the final paragraph of the draft.")
+    doc.save(docx_path)
+
+    # 2. Extract clean text using the CLI
+    rc_extract = _run_cli(["extract", "--clean-view", "--page", "all", str(docx_path), "-o", str(txt_path)])
+    assert rc_extract == 0, "CLI extract failed"
+    assert txt_path.exists(), "Extracted text file was not created"
+
+    # 3. Simulate a standard text editor save (adding a trailing newline)
+    orig_text = txt_path.read_text(encoding="utf-8")
+    txt_path.write_text(orig_text + "\n", encoding="utf-8")
+
+    # Clear capsys captured buffers
+    capsys.readouterr()
+
+    # 4. Run adeu diff CLI and assert that 0 changes are found
+    rc_diff = _run_cli(["diff", str(docx_path), str(txt_path)])
+    assert rc_diff == 0, f"adeu diff failed with exit code {rc_diff}"
+
+    captured_diff = capsys.readouterr()
+    assert "Found 0 changes" in captured_diff.err, (
+        f"Expected 0 changes to be found on diff, but got:\n{captured_diff.err}\n{captured_diff.out}"
+    )
+
+    # 5. Run adeu apply CLI and assert that 0 edits are applied
+    rc_apply = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(txt_path)])
+    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
+
+    captured_apply = capsys.readouterr()
+    assert "Edits: 0 applied" in captured_apply.err, (
+        f"Expected 0 edits to be applied, but got:\n{captured_apply.err}\n{captured_apply.out}"
+    )
+
+
+def test_apply_trailing_newline_table_repro(tmp_path, capsys):
+    """
+    Test that adeu diff and adeu apply correctly handle an accidental trailing newline
+    appended to the extracted text file for a document ending with a table.
+    Under the bug, the diff engine computes the trailing newline as a substantive insertion/change
+    and reports/applies it inside the table cell.
+    When fixed, the diff engine should detect and strip trailing blank lines or trailing whitespace
+    from the plain text file, and should not compute or apply any edits, resulting in 0 changes.
+    """
+    docx_path = tmp_path / "initial_table.docx"
+    txt_path = tmp_path / "extracted_table.txt"
+    out_path = tmp_path / "result_table.docx"
+
+    # 1. Create original docx ending with a table
+    doc = Document()
+    table = doc.add_table(rows=1, cols=1)
+    table.cell(0, 0).text = "Cell content"
+    doc.save(docx_path)
+
+    # 2. Extract clean text using the CLI
+    rc_extract = _run_cli(["extract", "--clean-view", "--page", "all", str(docx_path), "-o", str(txt_path)])
+    assert rc_extract == 0, "CLI extract failed"
+    assert txt_path.exists(), "Extracted text file was not created"
+
+    # 3. Simulate a standard text editor save (adding a trailing newline)
+    orig_text = txt_path.read_text(encoding="utf-8")
+    txt_path.write_text(orig_text + "\n", encoding="utf-8")
+
+    # Clear capsys captured buffers
+    capsys.readouterr()
+
+    # 4. Run adeu diff CLI and assert that 0 changes are found
+    rc_diff = _run_cli(["diff", str(docx_path), str(txt_path)])
+    assert rc_diff == 0, f"adeu diff failed with exit code {rc_diff}"
+
+    captured_diff = capsys.readouterr()
+    assert "Found 0 changes" in captured_diff.err, (
+        f"Expected 0 changes to be found on diff, but got:\n{captured_diff.err}\n{captured_diff.out}"
+    )
+
+    # 5. Run adeu apply CLI and assert that 0 edits are applied
+    rc_apply = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(txt_path)])
+    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
+
+    captured_apply = capsys.readouterr()
+    assert "Edits: 0 applied" in captured_apply.err, (
+        f"Expected 0 edits to be applied, but got:\n{captured_apply.err}\n{captured_apply.out}"
+    )


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
When `adeu diff` or `adeu apply` is executed with a text file as input, the engine extracts the clean text of the original document (`text_orig`) and loads the modified text (`text_mod`). Modern text editors automatically append a trailing newline on save. 

Because `text_orig` is generated programmatically from the `.docx` paragraph blocks, it does not contain a trailing newline. The extra trailing newline or trailing blank line in `text_mod` causes the paragraph-level alignment function `generate_edits_via_paragraph_alignment` to detect a mismatch. SequenceMatcher aligns the paragraphs but treats the final newline as either a substantive inline modification (`\n` added to the last word) or a trailing blank paragraph insertion (`\n\n` or `\n` at the end). This results in a phantom change being tracked in the final element of the document.

### The Fix
We addressed the issue at the **alignment layer**, which is the single most unified place to prevent this class of bug across both `diff` and `apply` commands.

We updated `generate_edits_via_paragraph_alignment` in both the Python engine (`src/adeu/diff.py`) and Node/TypeScript engine (`packages/core/src/diff.ts`). 
At the very beginning of the function, we extract the trailing whitespace characters from both `original_text` and `modified_text`. If the modified text's trailing whitespace differs from the original, we strip the trailing whitespace from `modified_text` and replace it with exactly the original text's trailing whitespace.

This guarantees that:
1. Accidental newlines, blank lines, or trailing spaces introduced by standard text editors are stripped.
2. The user's intended text edits in the final paragraph are perfectly preserved.
3. No phantom edits are generated or reported.

### Sibling Occurrences Found
We checked the codebase for other locations that split text on `\n\n` or perform paragraph/segment-level alignment. 
- In Python, we ensured that `src/adeu/diff.py`'s `generate_edits_via_paragraph_alignment` is the core shared entry point for text alignment.
- We mirrored the exact fix in the Node.js implementation (`node/packages/core/src/diff.ts`) to maintain complete engine parity.
- We added a regression test directly to the Node.js test suite in `diff.test.ts` to ensure coverage on the Node side as well.

### Verification
We performed extensive local verification from the required workspace environment:

1. **Python Package** (`adeu_isolated/python`):
   - Regression tests passed: `tests/test_cli_bug_repro.py::test_apply_trailing_newline_repro` and `tests/test_cli_bug_repro.py::test_apply_trailing_newline_table_repro` successfully passed.
   - Full test suite passed: `uv run pytest` (880 passed, 38 skipped).
   - Code formatting: Ran `uv run ruff check --fix .` and `uv run ruff format .` (fully clean, 1 file reformatted).
   - Type safety: Ran `uv run mypy src` (Success: no issues found in 30 source files).

2. **Node.js Package** (`adeu_isolated/node`):
   - Successfully ran `npm install` and `npm run build`.
   - All tests passed: `npm test` successfully executed 429 tests across all sub-workspaces, including the new Vitest regression test in `diff.test.ts` for trailing newlines.

### Risk Assessment & Follow-ups
- **Risk**: Extremely low. The fix only trims trailing whitespace/newlines of the modified input when they do not match the original text's trailing whitespace. All existing structure and formatting logic remains unchanged.
- **Follow-ups**: Monitor LLM-generated inputs in automated workflows to ensure any trailing markdown blocks are handled identically without trailing whitespace mismatches.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

# Bug Reproduction Report

## Chosen Bug
**S3 — Accidental Trailing Newline Captured as tracked change during text-file `apply`** (identified as the "Top Bug For This Iteration" in `eval_report.md`).

---

## Technical Details & Root Cause Analysis

### 1. Extracted Text Alignment Mechanics
When `adeu apply` is executed with a text file, it extracts clean text from the original Word document (`text_orig`) and reads the user-edited text file (`text_mod`). Both strings are then passed to `generate_edits_via_paragraph_alignment(text_orig, text_mod)` in `src/adeu/diff.py`.

### 2. Paragraph Splitting & Diff Alignment Bug
Inside `generate_edits_via_paragraph_alignment`, both files are split on double newlines `\n\n` to align paragraph blocks:
```python
orig_paragraphs = original_text.split("\n\n")
mod_paragraphs = modified_text.split("\n\n")
```

- When `original_text = "This is the final paragraph of the draft."`, `orig_paragraphs` is `["This is the final paragraph of the draft."]`.
- If a standard Unix-based text editor appends a trailing newline to the text file (e.g. `modified_text = "This is the final paragraph of the draft.\n"`), `mod_paragraphs` becomes `["This is the final paragraph of the draft.\n"]`.
- `generate_edits_from_text` aligns these as a `replace` block, and a word-level diffing is performed between `"This is the final paragraph of the draft."` and `"This is the final paragraph of the draft.\n"`, resulting in a `ModifyText` edit of `new_text="\n"` at the end of the text.
- If the editor saves the file with an extra blank line (e.g. `modified_text = "This is the final paragraph of the draft.\n\n"`), `mod_paragraphs` becomes `["This is the final paragraph of the draft.", ""]`.
- The alignment algorithm (`SequenceMatcher`) aligns index 0 as `"equal"` and treats index 1 (the extra empty string `""` at the end) as an `"insert"` operation. This causes the diff engine to emit a `ModifyText` edit of type `INSERTION` with `new_text="\n\n"` (or `\n`) anchored at the end.

### 3. Verification & UI Reporting Mismatches
Because of these phantom edits:
- `adeu diff` reports a substantive change (e.g., `Found 1 changes: [~] 'draft.' -> 'draft.\n'`) even though the user made no changes.
- `adeu apply` claims to have applied `1 edit`, but because the XML insertion code (`track_insert` in `src/adeu/redline/engine.py`) discards pure empty line insertions at the end of paragraphs, no actual changes are made to the `.docx` file XML structure.
- The command exits with `0` and prints `Edits: 1 applied`, which is misleading and causes pipelines to believe the document structure was modified.

---

## Minimal Reproduction Commands

### Case A: Simple Paragraph
1. Create a `.docx` containing a single paragraph:
   ```bash
   uv run python -c "import docx; doc = docx.Document(); doc.add_paragraph('This is the final paragraph of the draft.'); doc.save('initial.docx')"
   ```
2. Extract clean text representation:
   ```bash
   uv run adeu extract --clean-view --page all -o extracted.txt initial.docx
   ```
3. Append a trailing newline:
   ```bash
   echo "" >> extracted.txt
   ```
4. Run diff:
   ```bash
   uv run adeu diff initial.docx extracted.txt
   ```
   *Expected:* `Found 0 changes:`
   *Actual:* `Found 1 changes: [~] 'draft.' -> 'draft.\n'`

---

## Regression Tests Added

The following two permanent regression tests were added to `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py`:

```python
def test_apply_trailing_newline_repro(tmp_path, capsys):
    """
    Test that adeu diff and adeu apply correctly handle an accidental trailing newline
    appended to the extracted text file (e.g. by a standard text editor on save).
    Under the bug, the diff engine computes the trailing newline as a substantive insertion/change
    and reports/applies it.
    When fixed, the diff engine should detect and strip trailing blank lines or trailing whitespace
    from the plain text file, and should not compute or apply any edits, resulting in 0 changes.
    """
    docx_path = tmp_path / "initial.docx"
    txt_path = tmp_path / "extracted.txt"
    out_path = tmp_path / "result.docx"

    # 1. Create original docx with a single paragraph
    doc = Document()
    doc.add_paragraph("This is the final paragraph of the draft.")
    doc.save(docx_path)

    # 2. Extract clean text using the CLI
    rc_extract = _run_cli(["extract", "--clean-view", "--page", "all", str(docx_path), "-o", str(txt_path)])
    assert rc_extract == 0, "CLI extract failed"
    assert txt_path.exists(), "Extracted text file was not created"

    # 3. Simulate a standard text editor save (adding a trailing newline)
    orig_text = txt_path.read_text(encoding="utf-8")
    txt_path.write_text(orig_text + "\n", encoding="utf-8")

    # Clear capsys captured buffers
    capsys.readouterr()

    # 4. Run adeu diff CLI and assert that 0 changes are found
    rc_diff = _run_cli(["diff", str(docx_path), str(txt_path)])
    assert rc_diff == 0, f"adeu diff failed with exit code {rc_diff}"
    
    captured_diff = capsys.readouterr()
    assert "Found 0 changes" in captured_diff.err, (
        f"Expected 0 changes to be found on diff, but got:\n{captured_diff.err}\n{captured_diff.out}"
    )

    # 5. Run adeu apply CLI and assert that 0 edits are applied
    rc_apply = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(txt_path)])
    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
    
    captured_apply = capsys.readouterr()
    assert "Edits: 0 applied" in captured_apply.err, (
        f"Expected 0 edits to be applied, but got:\n{captured_apply.err}\n{captured_apply.out}"
    )


def test_apply_trailing_newline_table_repro(tmp_path, capsys):
    """
    Test that adeu diff and adeu apply correctly handle an accidental trailing newline
    appended to the extracted text file for a document ending with a table.
    Under the bug, the diff engine computes the trailing newline as a substantive insertion/change
    and reports/applies it inside the table cell.
    When fixed, the diff engine should detect and strip trailing blank lines or trailing whitespace
    from the plain text file, and should not compute or apply any edits, resulting in 0 changes.
    """
    docx_path = tmp_path / "initial_table.docx"
    txt_path = tmp_path / "extracted_table.txt"
    out_path = tmp_path / "result_table.docx"

    # 1. Create original docx ending with a table
    doc = Document()
    table = doc.add_table(rows=1, cols=1)
    table.cell(0, 0).text = "Cell content"
    doc.save(docx_path)

    # 2. Extract clean text using the CLI
    rc_extract = _run_cli(["extract", "--clean-view", "--page", "all", str(docx_path), "-o", str(txt_path)])
    assert rc_extract == 0, "CLI extract failed"
    assert txt_path.exists(), "Extracted text file was not created"

    # 3. Simulate a standard text editor save (adding a trailing newline)
    orig_text = txt_path.read_text(encoding="utf-8")
    txt_path.write_text(orig_text + "\n", encoding="utf-8")

    # Clear capsys captured buffers
    capsys.readouterr()

    # 4. Run adeu diff CLI and assert that 0 changes are found
    rc_diff = _run_cli(["diff", str(docx_path), str(txt_path)])
    assert rc_diff == 0, f"adeu diff failed with exit code {rc_diff}"
    
    captured_diff = capsys.readouterr()
    assert "Found 0 changes" in captured_diff.err, (
        f"Expected 0 changes to be found on diff, but got:\n{captured_diff.err}\n{captured_diff.out}"
    )

    # 5. Run adeu apply CLI and assert that 0 edits are applied
    rc_apply = _run_cli(["apply", "-o", str(out_path), str(docx_path), str(txt_path)])
    assert rc_apply == 0, f"adeu apply failed with exit code {rc_apply}"
    
    captured_apply = capsys.readouterr()
    assert "Edits: 0 applied" in captured_apply.err, (
        f"Expected 0 edits to be applied, but got:\n{captured_apply.err}\n{captured_apply.out}"
    )


</details>
