### PR TITLE
fix: prevent finalize_document crash when finalization is blocked

### DIFF
--- a/node/packages/mcp-server/src/index.ts
+++ b/node/packages/mcp-server/src/index.ts
@@ -853,16 +853,26 @@ server.registerTool(
         export_pdf: export_pdf as boolean,
       });
 
-      fs.writeFileSync(outPath, result.outBuffer!);
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Saved to: ${outPath}\n\n${result.reportText}`,
-          },
-        ],
-      };
+      if (result.outBuffer) {
+        fs.writeFileSync(outPath, result.outBuffer);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Saved to: ${outPath}\n\n${result.reportText}`,
+            },
+          ],
+        };
+      } else {
+        return {
+          content: [
+            {
+              type: "text",
+              text: result.reportText,
+            },
+          ],
+        };
+      }
     } catch (e: any) {
       return {
         isError: true,

--- a/node/packages/mcp-server/src/repro_agy_bug.test.ts
+++ b/node/packages/mcp-server/src/repro_agy_bug.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, ChildProcess } from "node:child_process";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { DocumentObject, RedlineEngine } from "@adeu/core";
+
+describe("QA Regression Test - Finding 1: finalize_document crash on missing sanitize_mode with tracked changes", () => {
+  let serverProc: ChildProcess;
+  let trackedDocPath: string;
+  let outputDocPath: string;
+
+  beforeAll(async () => {
+    // 1. Grab the shared golden fixture from the monorepo root
+    const fixturePath = resolve(
+      __dirname,
+      "../../../../shared/fixtures/golden.docx",
+    );
+
+    trackedDocPath = join(tmpdir(), `adeu_regression_tracked_${Date.now()}.docx`);
+    outputDocPath = join(tmpdir(), `adeu_regression_output_${Date.now()}.docx`);
+
+    // Load fixture and dirty it to create unresolved tracked changes
+    const fixtureBuf = readFileSync(fixturePath);
+    const doc = await DocumentObject.load(fixtureBuf);
+    const engine = new RedlineEngine(doc, "Reviewer");
+
+    // Modify a piece of text to generate a tracked change
+    engine.process_batch([
+      {
+        type: "modify",
+        target_text: "document",
+        new_text: "modified tracked document",
+      },
+    ]);
+    writeFileSync(trackedDocPath, await doc.save());
+
+    // 2. Boot the compiled MCP server
+    const serverPath = resolve(__dirname, "../dist/index.js");
+    if (!existsSync(serverPath)) {
+      throw new Error(
+        "MCP server not built. Run 'npm run build' before running tests.",
+      );
+    }
+
+    serverProc = spawn("node", [serverPath]);
+  });
+
+  afterAll(() => {
+    if (serverProc && !serverProc.killed) serverProc.kill();
+    if (existsSync(trackedDocPath)) unlinkSync(trackedDocPath);
+    if (existsSync(outputDocPath)) unlinkSync(outputDocPath);
+  });
+
+  // Helper to interact with the stdio JSON-RPC server
+  function sendRpc(method: string, params: any, id: number = 1): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("RPC Timeout")), 5000);
+
+      const listener = (data: Buffer) => {
+        const lines = data.toString().trim().split("\n");
+        for (const line of lines) {
+          if (!line.startsWith("{")) continue;
+          try {
+            const res = JSON.parse(line);
+            if (res.id === id) {
+              clearTimeout(timeout);
+              serverProc.stdout?.removeListener("data", listener);
+              resolve(res);
+            }
+          } catch (e) {
+            // Ignore incomplete chunks
+          }
+        }
+      };
+
+      serverProc.stdout?.on("data", listener);
+      serverProc.stdin?.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
+    });
+  }
+
+  it("should return a clean block report instead of crashing when sanitize_mode is omitted with tracked changes", async () => {
+    const res = await sendRpc(
+      "tools/call",
+      {
+        name: "finalize_document",
+        arguments: {
+          reasoning: "Finalize document containing unresolved tracked changes without sanitize_mode",
+          file_path: trackedDocPath,
+          output_path: outputDocPath,
+        },
+      },
+      201,
+    );
+
+    // Assert that the tool does not crash or return a TypeError
+    expect(res.error).toBeUndefined();
+    expect(res.result).toBeDefined();
+    
+    // It should NOT be an error/crash response.
+    // (A blocked finalization is a clean business logic result, not a fatal RPC / NodeJS error)
+    expect(res.result.isError).toBeUndefined();
+    
+    const responseText = res.result.content[0].text;
+    expect(responseText).not.toContain("TypeError");
+    expect(responseText).not.toContain("must be of type string");
+    
+    // It must contain the blocked report indicating unresolved tracked changes
+    expect(responseText.toLowerCase()).toContain("blocked");
+    expect(responseText).toContain("unresolved tracked changes");
+    
+    // Proves that no file was written
+    expect(existsSync(outputDocPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Agentic Auto-Fix (MCP (node))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
When calling `finalize_document` on a document with unresolved tracked changes without `accept_all=true` or an explicit `sanitize_mode` that allows finalization, the core engine blocks finalization by design. It returns a success status result with a `reportText` detailing why it was blocked but leaving `outBuffer` undefined (since the finalization was blocked, no final document could be saved).
The MCP server's tool handler, however, unconditionally assumed that `result.outBuffer` was defined and attempted to write it to disk using `fs.writeFileSync(outPath, result.outBuffer!)`. This threw a `TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined`, which was then caught in the catch-all block, resulting in a fatal RPC error response where `isError` was set to `true`, instead of returning a clean, informative blocked finalization report.

### The Fix
In `node/packages/mcp-server/src/index.ts`:
- Added a conditional check on `result.outBuffer` inside the `finalize_document` tool handler.
- If `result.outBuffer` is present, the buffer is saved via `fs.writeFileSync` as before, and the tool returns a success result containing the filepath and the report.
- If `result.outBuffer` is undefined (finalization was blocked), we skip `fs.writeFileSync` and return a successful MCP response containing only the text-based blocked report cleanly, avoiding process crashes or setting `isError: true`.
- Modified `node/packages/mcp-server/src/repro_agy_bug.test.ts` to make the assertion case-insensitive (`expect(responseText.toLowerCase()).toContain("blocked")`) to correctly match `"BLOCKED:"` returned by the core engine.

### Sibling Occurrences
Searched other files in the node codebase for patterns of `writeFileSync` without validation:
- `node/packages/mcp-server/src/index.ts` line 631 in `process_document_batch`: Handles filesystem errors cleanly via try/catch and guarantees `outBuf` exists (since `doc.save()` always returns a buffer unless it throws a core error).
- `node/packages/mcp-server/src/index.ts` line 697 in `accept_all_changes`: Guarantees `outBuf` exists.
No other conditional-blocking patterns with missing output buffers exist.

### Verification
Ran the build and tests locally within the workspace:
1. `npm run build` from `node/` completed successfully (validating TypeScript type-safety).
2. `npx vitest run src/repro_agy_bug.test.ts` completed successfully:
   ```
   RUN  v4.1.7 /Users/mkorpela/workspace/agy-loop/workspaces/mcp_node_reproduce/adeu_isolated/node/packages/mcp-server
   ✓ src/repro_agy_bug.test.ts (1 test) 169ms
   ```
3. `npm test` completed successfully across all 3 packages:
   - `@adeu/core`: 361 tests passed.
   - `@adeu/mcp-server`: 51 tests passed.
   - `n8n-nodes-adeu`: 19 tests passed.
   - Total of 431 tests passed with no regressions.

### Risk Assessment and Suggested Follow-ups
- **Risk Level**: Extremely low. The fix only adds a safety check for a missing file buffer when finalization is blocked, preserving the existing logic for successfully finalized documents.
- **Parity Follow-up**: The Python core implementation and Python MCP server should be checked to ensure that similar conditions (omitting `sanitize_mode` or finalization blocking with tracked changes) are handled gracefully without throwing standard type errors or process failures.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: node/packages/mcp-server/src/repro_agy_bug.test.ts

### The Bug Description and Severity
* **Severity**: S1 (Crash / Fatal)
* **Description**: When invoking the `finalize_document` MCP tool on a DOCX document that contains unresolved tracked changes, if the `sanitize_mode` parameter is omitted (or explicitly set to `"full"`) and the `accept_all` parameter is not set to `true`, the core engine blocks finalization by returning a result report without an `outBuffer`. Due to this, the MCP server's tool handler attempts to write a non-existent buffer with `fs.writeFileSync(outPath, result.outBuffer!)`, which crashes the Node.js process / session with `Error: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined` instead of returning a clean, informative error/blocked status report.

---

### Minimal Reproduction
#### 1. Input Document Generation
A DOCX file (e.g. `tracked.docx`) containing unresolved tracked changes. This can be built programmatically using the `RedlineEngine` to modify some text in a base document and saving:
```typescript
const doc = await DocumentObject.load(baseBuffer);
const engine = new RedlineEngine(doc, "Reviewer");
engine.process_batch([{ type: "modify", target_text: "original", new_text: "modified" }]);
const trackedBuffer = await doc.save();
```

#### 2. MCP Tool Call Payload (sanitize_mode Omitted)
```json
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "tools/call",
  "params": {
    "name": "finalize_document",
    "arguments": {
      "reasoning": "Finalize with minimal arguments.",
      "file_path": "/path/to/tracked.docx",
      "output_path": "/path/to/output.docx"
    }
  }
}
```

#### 3. Actual Unpatched Outcome
The server catches a `TypeError` thrown from `fs.writeFileSync` and returns `isError: true`:
```json
{
  "result": {
    "content": [
      {
        "type": "text",
        "text": "Error: The \"data\" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined"
      }
    ],
    "isError": true
  },
  "jsonrpc": "2.0",
  "id": 42
}
```

---

### Full Test Code
The regression test has been successfully registered at `node/packages/mcp-server/src/repro_agy_bug.test.ts`:
```typescript
import { describe, it, expect, beforeAll, afterAll } from "vitest";
import { spawn, ChildProcess } from "node:child_process";
import { resolve, join } from "node:path";
import { tmpdir } from "node:os";
import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
import { DocumentObject, RedlineEngine } from "@adeu/core";

describe("QA Regression Test - Finding 1: finalize_document crash on missing sanitize_mode with tracked changes", () => {
  let serverProc: ChildProcess;
  let trackedDocPath: string;
  let outputDocPath: string;

  beforeAll(async () => {
    // 1. Grab the shared golden fixture from the monorepo root
    const fixturePath = resolve(
      __dirname,
      "../../../../shared/fixtures/golden.docx",
    );

    trackedDocPath = join(tmpdir(), `adeu_regression_tracked_${Date.now()}.docx`);
    outputDocPath = join(tmpdir(), `adeu_regression_output_${Date.now()}.docx`);

    // Load fixture and dirty it to create unresolved tracked changes
    const fixtureBuf = readFileSync(fixturePath);
    const doc = await DocumentObject.load(fixtureBuf);
    const engine = new RedlineEngine(doc, "Reviewer");

    // Modify a piece of text to generate a tracked change
    engine.process_batch([
      {
        type: "modify",
        target_text: "document",
        new_text: "modified tracked document",
      },
    ]);
    writeFileSync(trackedDocPath, await doc.save());

    // 2. Boot the compiled MCP server
    const serverPath = resolve(__dirname, "../dist/index.js");
    if (!existsSync(serverPath)) {
      throw new Error(
        "MCP server not built. Run 'npm run build' before running tests.",
      );
    }

    serverProc = spawn("node", [serverPath]);
  });

  afterAll(() => {
    if (serverProc && !serverProc.killed) serverProc.kill();
    if (existsSync(trackedDocPath)) unlinkSync(trackedDocPath);
    if (existsSync(outputDocPath)) unlinkSync(outputDocPath);
  });

  // Helper to interact with the stdio JSON-RPC server
  function sendRpc(method: string, params: any, id: number = 1): Promise<any> {
    return new Promise((resolve, reject) => {
      const timeout = setTimeout(() => reject(new Error("RPC Timeout")), 5000);

      const listener = (data: Buffer) => {
        const lines = data.toString().trim().split("\n");
        for (const line of lines) {
          if (!line.startsWith("{")) continue;
          try {
            const res = JSON.parse(line);
            if (res.id === id) {
              clearTimeout(timeout);
              serverProc.stdout?.removeListener("data", listener);
              resolve(res);
            }
          } catch (e) {
            // Ignore incomplete chunks
          }
        }
      };

      serverProc.stdout?.on("data", listener);
      serverProc.stdin?.write(
        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
      );
    });
  }

  it("should return a clean block report instead of crashing when sanitize_mode is omitted with tracked changes", async () => {
    const res = await sendRpc(
      "tools/call",
      {
        name: "finalize_document",
        arguments: {
          reasoning: "Finalize document containing unresolved tracked changes without sanitize_mode",
          file_path: trackedDocPath,
          output_path: outputDocPath,
        },
      },
      201,
    );

    // Assert that the tool does not crash or return a TypeError
    expect(res.error).toBeUndefined();
    expect(res.result).toBeDefined();
    
    // It should NOT be an error/crash response.
    // (A blocked finalization is a clean business logic result, not a fatal RPC / NodeJS error)
    expect(res.result.isError).toBeUndefined();
    
    const responseText = res.result.content[0].text;
    expect(responseText).not.toContain("TypeError");
    expect(responseText).not.toContain("must be of type string");
    
    // It must contain the blocked report indicating unresolved tracked changes
    expect(responseText).toContain("blocked");
    expect(responseText).toContain("unresolved tracked changes");
    
    // Proves that no file was written
    expect(existsSync(outputDocPath)).toBe(false);
  });
});
```

---

### Vitest Failure Output Proving Correct Failure Reason
```
 RUN  v4.1.7 /Users/mkorpela/workspace/agy-loop/workspaces/mcp_node_reproduce/adeu_isolated/node/packages/mcp-server

 ❯ src/repro_agy_bug.test.ts (1 test | 1 failed) 202ms
     × should return a clean block report instead of crashing when sanitize_mode is omitted with tracked changes 159ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/repro_agy_bug.test.ts > QA Regression Test - Finding 1: finalize_document crash on missing sanitize_mode with tracked changes > should return a clean block report instead of crashing when sanitize_mode is omitted with tracked changes
AssertionError: expected true to be undefined

- Expected:
undefined

+ Received:
true

 ❯ src/repro_agy_bug.test.ts:104:32
    102|     // It should NOT be an error/crash response.
    103|     // (A blocked finalization is a clean business logic result, not a…
    104|     expect(res.result.isError).toBeUndefined();
       |                                ^
    105|
    106|     const responseText = res.result.content[0].text;

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

---

### Expected Behavior Once Fixed
When `finalize_document` is invoked on a document with unresolved tracked changes and without `accept_all=true`:
1. The tool should detect that `result.outBuffer` is undefined/absent because finalization was blocked.
2. The tool should **never** call `fs.writeFileSync` when `result.outBuffer` is undefined/absent.
3. The tool should return a successful MCP response structure (i.e. without setting `isError: true` or returning a fatal NodeJS error payload) containing the plain text block report (detailing the status as `blocked` and listing the unresolved tracked changes).


</details>
