### PR TITLE
fix: Automated agentic MCP (python) bug fix

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -181,11 +181,13 @@ def _cli_error(code: str, message: str, exit_code: int = 1, hint: "str | None" =
     Stable codes: file_not_found, invalid_input, invalid_docx,
     invalid_changes_file, write_failed, unsupported, batch_validation_failed.
     """
-    print(f"❌ {message}", file=sys.stderr)
+    display_msg = message if message.startswith("❌") else f"❌ {message}"
+    print(display_msg, file=sys.stderr)
     if hint:
         print(hint, file=sys.stderr)
     if _JSON_MODE:
-        print(json.dumps({"error": code, "message": message}))
+        clean_msg = message[1:].strip() if message.startswith("❌") else message
+        print(json.dumps({"error": code, "message": clean_msg}))
     sys.exit(exit_code)
 
 
@@ -1409,43 +1411,43 @@ def handle_markup(args):
 
 
 def handle_sanitize(args: argparse.Namespace):
+    _set_json_mode(getattr(args, "json", False))
     from adeu.redline.engine import describe_illegal_control_chars
 
     author_ctrl = describe_illegal_control_chars(args.author or "")
     if author_ctrl:
-        print(
-            f"❌ --author contains control character(s) ({author_ctrl}) that cannot be "
+        _cli_error(
+            "invalid_input",
+            f"--author contains control character(s) ({author_ctrl}) that cannot be "
             "stored in a DOCX. Remove them and re-run.",
-            file=sys.stderr,
+            exit_code=2,
         )
-        sys.exit(2)
 
     _require_docx_output(args.output)
 
     # Contradictory option combinations are usage errors, never silent
     # preferences (QA 2026-07-19 F-07/F-08).
     if args.keep_markup and args.accept_all:
-        print(
-            "❌ --keep-markup and --accept-all are mutually exclusive: --keep-markup preserves "
+        _cli_error(
+            "invalid_input",
+            "--keep-markup and --accept-all are mutually exclusive: --keep-markup preserves "
             "tracked changes and comments, --accept-all resolves them into the text. "
             "Pass exactly one of them.",
-            file=sys.stderr,
+            exit_code=2,
         )
-        sys.exit(2)
     if args.output and args.outdir:
-        print(
-            "❌ -o/--output and --outdir are mutually exclusive: -o names a single output file, "
+        _cli_error(
+            "invalid_input",
+            "-o/--output and --outdir are mutually exclusive: -o names a single output file, "
             "--outdir selects batch mode. Pass exactly one of them.",
-            file=sys.stderr,
+            exit_code=2,
         )
-        sys.exit(2)
 
     input_files: List[Path] = args.input
     is_batch = len(input_files) > 1 or args.outdir
 
     if not is_batch and args.baseline and len(input_files) > 1:
-        print("❌ --baseline only works with a single input file.", file=sys.stderr)
-        sys.exit(2)
+        _cli_error("invalid_input", "--baseline only works with a single input file.", exit_code=2)
 
     if not is_batch and len(input_files) == 1:
         # Single file mode
@@ -1484,11 +1486,26 @@ def handle_sanitize(args: argparse.Namespace):
                 if args.report_file:
                     _write_report_file(args.report_file, result.report_text)
 
-            print(f"✅ Sanitized → {output_path}", file=sys.stderr)
+            if getattr(args, "json", False):
+                res = {
+                    "status": result.status,
+                    "input_path": str(input_path),
+                    "output_path": str(output_path),
+                    "tracked_changes_found": result.tracked_changes_found,
+                    "tracked_changes_accepted": result.tracked_changes_accepted,
+                    "comments_removed": result.comments_removed,
+                    "comments_kept": result.comments_kept,
+                    "metadata_stripped": result.metadata_stripped,
+                    "warnings": result.warnings,
+                }
+                if args.report:
+                    res["report_text"] = result.report_text
+                print(json.dumps(res))
+            else:
+                print(f"✅ Sanitized → {output_path}", file=sys.stderr)
 
         except SanitizeError as e:
-            print(str(e), file=sys.stderr)
-            sys.exit(1)
+            _cli_error("invalid_input", str(e))
         except FileNotFoundError as e:
             _cli_error("file_not_found", str(e))
         except Exception as e:
@@ -1628,7 +1645,34 @@ def handle_sanitize(args: argparse.Namespace):
         summary = f"\nBatch Summary: {total} documents processed, {succeeded} succeeded, {blocked} blocked"
         if blocked > 0:
             summary += "\nBatch failed — no outputs were written (the batch is all-or-nothing)."
-        print(summary, file=sys.stderr)
+
+        if getattr(args, "json", False):
+            batch_results: List[Dict[str, Any]] = []
+            for r in all_reports:
+                if isinstance(r, (SanitizeError, Exception)):
+                    batch_results.append({"status": "blocked", "error": str(r)})
+                else:
+                    item = {
+                        "status": r.status,
+                        "output_path": r.output_path,
+                        "tracked_changes_found": r.tracked_changes_found,
+                        "tracked_changes_accepted": r.tracked_changes_accepted,
+                        "comments_removed": r.comments_removed,
+                        "comments_kept": r.comments_kept,
+                        "metadata_stripped": r.metadata_stripped,
+                        "warnings": r.warnings,
+                    }
+                    batch_results.append(item)
+            payload = {
+                "status": "ok" if blocked == 0 else "blocked",
+                "total": total,
+                "succeeded": succeeded,
+                "blocked": blocked,
+                "results": batch_results,
+            }
+            print(json.dumps(payload))
+        else:
+            print(summary, file=sys.stderr)
 
         # Write reports
         if args.report or args.report_file:
@@ -1967,6 +2011,11 @@ def _main_impl():
         "--report-file",
         type=Path,
         help="Write report to file",
+    )
+    p_sanitize.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON result on stdout.",
     )
     p_sanitize.set_defaults(func=handle_sanitize)
 

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -822,3 +822,55 @@ def test_read_docx_appendix_mode_schema_compat(tmp_path):
 
     # Assert that the result was successful and contains appendix information
     assert "Agreement" in text
+
+
+def test_sanitize_cli_accepts_json_flag(tmp_path, capsys):
+    """
+    Verifies that 'adeu sanitize' accepts the --json flag instead of failing
+    with 'unrecognized arguments: --json' (exit 2).
+    Under --json, adeu sanitize must output a machine-readable JSON result on stdout.
+    """
+    import json
+    from unittest.mock import patch
+
+    from docx import Document
+
+    from adeu.cli import main
+
+    # 1. Create a test docx
+    doc = Document()
+    doc.add_paragraph("Contract text to sanitize")
+    input_path = tmp_path / "contract.docx"
+    output_path = tmp_path / "contract_sanitized.docx"
+    doc.save(str(input_path))
+
+    # 2. Run adeu sanitize with --json
+    code = 0
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "adeu",
+            "sanitize",
+            str(input_path),
+            "-o",
+            str(output_path),
+            "--json",
+        ],
+    ):
+        try:
+            main()
+        except SystemExit as e:
+            code = e.code or 0
+
+    captured = capsys.readouterr()
+
+    # Must not fail with argparse usage/unrecognized argument error (exit code 2)
+    assert code != 2, f"adeu sanitize failed with argparse error (code 2): {captured.err}"
+    assert "unrecognized arguments: --json" not in captured.err, f"adeu sanitize rejected --json flag: {captured.err}"
+
+    # Success path should exit 0 and emit valid JSON on stdout
+    assert code == 0, f"adeu sanitize failed with exit code {code}: {captured.err}"
+    assert captured.out.strip(), "Expected JSON output on stdout, got empty stdout"
+    data = json.loads(captured.out)
+    assert "output_path" in data or "file_path" in data or "status" in data


### PR DESCRIPTION
## Agentic Auto-Fix (MCP (python))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[15:10:02] An issue was identified where `adeu sanitize` failed with `argparse` exit code 2 (`unrecognized arguments: --json`) because the subcommand parser lacked the `--json` option definition, and `handle_sanitize` did not configure JSON execution mode or output structured JSON results.
[15:10:02] 
[15:10:02] ### Root Cause
[15:10:02] 1. `p_sanitize` in `src/adeu/cli.py` did not define `p_sanitize.add_argument("--json", action="store_true", ...)` like other subcommands (`extract`, `apply`, `accept-all`, `markup`).
[15:10:02] 2. `handle_sanitize` did not initialize JSON mode via `_set_json_mode()` and did not format output as JSON when requested.
[15:10:02] 
[15:10:02] ### Key Changes
[15:10:02] - **Parser Update**: Added `--json` argument to `p_sanitize` in `src/adeu/cli.py`.
[15:10:02] - **Handler Update**:
[15:10:02]   - Called `_set_json_mode(getattr(args, "json", False))` at entry of `handle_sanitize`.
[15:10:02]   - Replaced direct `sys.exit(2)` calls with `_cli_error(..., exit_code=2)` to ensure error contract consistency under `--json`.
[15:10:02]   - Added JSON structured output formatting for both single-file mode and batch mode in `handle_sanitize`.
[15:10:02]   - Routed `SanitizeError` and file exceptions through `_cli_error("invalid_input", str(e))` for structured JSON error output on failure.
[15:10:02]   - Updated `_cli_error` to handle messages that already begin with `❌` without duplicating prefixes.
[15:10:02] - **Type Annotations**: Annotated `batch_results` in `handle_sanitize` as `List[Dict[str, Any]]` to pass static type checking.
[15:10:02] - **Regression Test**: Added `test_sanitize_cli_accepts_json_flag` in `tests/test_cli_bug_repro.py`.
[15:10:02] 
[15:10:02] ### Verification
[15:10:02] - `uv run pytest tests/test_cli_bug_repro.py::test_sanitize_cli_accepts_json_flag` passed.
[15:10:02] - `uv run ruff check --fix .` and `uv run ruff format .` passed.
[15:10:02] - `uv run mypy src` passed with 0 errors resolved cleanly passed with 0 issues.
[15:10:21] ### Resolution Summary
[15:10:21] 
[15:10:21] #### 1. Issue Identified
[15:10:21] The `adeu sanitize` CLI command raised an `argparse` error (`unrecognized arguments: --json`) and exited with code 2 because the subcommand parser lacked the `--json` option definition, and `handle_sanitize` was not configured to emit structured JSON results or process CLI errors under `_JSON_MODE`.
[15:10:21] 
[15:10:21] #### 2. Changes Made
[15:10:22] - **Parser (`p_sanitize`)**: Added `--json` flag to `p_sanitize` in `src/adeu/cli.py`.
[15:10:22] - **CLI Handler (`handle_sanitize`)**:
[15:10:22]   - Invoked `_set_json_mode(getattr(args, "json", False))` at the start of `handle_sanitize`.
[15:10:22]   - Updated single-file and batch mode success handlers to output structured JSON when `--json` is enabled.
[15:10:22]   - Replaced raw `sys.exit(2)` and `sys.exit(1)` error paths in `handle_sanitize` with `_cli_error(...)` calls to ensure uniform error objects (`{"error": code, "message": msg}`) are printed on `stdout` when `--json` is specified.
[15:10:22] - **Error Formatting (`_cli_error`)**: Defensive check added to strip or avoid prepending duplicate `❌` prefixes when formatting error strings for JSON messages.
[15:10:22] - **Typing**: Explicitly annotated `batch_results: List[Dict[str, Any]]` to pass `mypy`.
[15:10:22] - **Regression Test**: Added `test_sanitize_cli_accepts_json_flag` in `tests/test_cli_bug_repro.py`.
[15:10:22] 
[15:10:22] #### 3. Verification
[15:10:23] - `uv run pytest tests/test_cli_bug_repro.py::test_sanitize_cli_accepts_json_flag` passed.
[15:10:23] - `uv run ruff check --fix .` and `uv run ruff format .` passed.
[15:10:23] - `uv run mypy src` passed cleanly.
[15:10:23] - Full Python test suite (`uv run pytest`) passed (905 passed, 38 skipped).
[15:10:23] - Node suite (`npm run build && npm test`) passed (451 tests across 58 test files passed).


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/mcp_py_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description
The CLI command `adeu sanitize` fails to support the standard `--json` CLI flag, exiting with code 2 and `adeu sanitize: error: unrecognized arguments: --json`. While all other subcommands (`extract`, `diff`, `apply`, `accept-all`, `markup`) support `--json` to output machine-readable JSON payloads and errors (as required by Adeu's CLI failure contract and stream conventions), `p_sanitize` in `adeu/cli.py` omits `--json` from its argument parser and `handle_sanitize` does not enable JSON mode. This causes automated scripts and AI agents following Adeu's own fallback error instructions to break with `unrecognized arguments: --json`. This is an S3 (UX / CLI Consistency) defect. Note: Finding 1 in the QA evaluation report ("Printf string formatting specifiers in error message") was evaluated against `AI_CONTEXT.md` and confirmed to be intended behavior (literal `%` signs in report text, per invariant 109).

### Minimal Reproduction
1. Create a minimal `.docx` file (e.g. `doc = docx.Document(); doc.add_paragraph("Test"); doc.save("contract.docx")`).
2. Run `adeu sanitize contract.docx -o output.docx --json`.
3. Observe the CLI failure:
   ```
   usage: adeu sanitize [-h] [-o OUTPUT] [--outdir OUTDIR] [--keep-markup]
                        [--baseline BASELINE] [--allow-low-similarity-baseline]
                        [--author AUTHOR] [--accept-all] [--report]
                        [--report-file REPORT_FILE]
                        input [input ...]
   adeu sanitize: error: unrecognized arguments: --json
   ```
   (exit code 2).

### Full Test Code
```python
def test_sanitize_cli_accepts_json_flag(tmp_path, capsys):
    """
    Verifies that 'adeu sanitize' accepts the --json flag instead of failing
    with 'unrecognized arguments: --json' (exit 2).
    Under --json, adeu sanitize must output a machine-readable JSON result on stdout.
    """
    import json
    from unittest.mock import patch

    from docx import Document
    from adeu.cli import main

    # 1. Create a test docx
    doc = Document()
    doc.add_paragraph("Contract text to sanitize")
    input_path = tmp_path / "contract.docx"
    output_path = tmp_path / "contract_sanitized.docx"
    doc.save(str(input_path))

    # 2. Run adeu sanitize with --json
    code = 0
    with patch.object(
        sys,
        "argv",
        [
            "adeu",
            "sanitize",
            str(input_path),
            "-o",
            str(output_path),
            "--json",
        ],
    ):
        try:
            main()
        except SystemExit as e:
            code = e.code or 0

    captured = capsys.readouterr()

    # Must not fail with argparse usage/unrecognized argument error (exit code 2)
    assert code != 2, f"adeu sanitize failed with argparse error (code 2): {captured.err}"
    assert "unrecognized arguments: --json" not in captured.err, (
        f"adeu sanitize rejected --json flag: {captured.err}"
    )

    # Success path should exit 0 and emit valid JSON on stdout
    assert code == 0, f"adeu sanitize failed with exit code {code}: {captured.err}"
    assert captured.out.strip(), "Expected JSON output on stdout, got empty stdout"
    data = json.loads(captured.out)
    assert "output_path" in data or "file_path" in data or "status" in data
```

### Pytest Failure Output
```
_____________________ test_sanitize_cli_accepts_json_flag ______________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-435/test_sanitize_cli_accepts_json0')
capsys = <_pytest.capture.CaptureFixture object at 0x10b0855b0>

    def test_sanitize_cli_accepts_json_flag(tmp_path, capsys):
        """
        Verifies that 'adeu sanitize' accepts the --json flag instead of failing
        with 'unrecognized arguments: --json' (exit 2).
        Under --json, adeu sanitize must output a machine-readable JSON result on stdout.
        """
        import json
        from unittest.mock import patch
    
        from docx import Document
        from adeu.cli import main
    
        # 1. Create a test docx
        doc = Document()
        doc.add_paragraph("Contract text to sanitize")
        input_path = tmp_path / "contract.docx"
        output_path = tmp_path / "contract_sanitized.docx"
        doc.save(str(input_path))
    
        # 2. Run adeu sanitize with --json
        code = 0
        with patch.object(
            sys,
            "argv",
            [
                "adeu",
                "sanitize",
                str(input_path),
                "-o",
                str(output_path),
                "--json",
            ],
        ):
            try:
                main()
            except SystemExit as e:
                code = e.code or 0
    
        captured = capsys.readouterr()
    
        # Must not fail with argparse usage/unrecognized argument error (exit code 2)
>       assert code != 2, f"adeu sanitize failed with argparse error (code 2): {captured.err}"
E       AssertionError: adeu sanitize failed with argparse error (code 2): usage: adeu sanitize [-h] [-o OUTPUT] [--outdir OUTDIR] [--keep-markup]
E                              [--baseline BASELINE] [--allow-low-similarity-baseline]
E                              [--author AUTHOR] [--accept-all] [--report]
E                              [--report-file REPORT_FILE]
E                              input [input ...]
E         adeu sanitize: error: unrecognized arguments: --json
E         
E       assert 2 != 2

tests/test_cli_bug_repro.py:868: AssertionError
```

### Expected Behavior Once Fixed
When running `adeu sanitize <input.docx> [options] --json`, `argparse` recognizes the `--json` flag, sets JSON mode (`_set_json_mode(True)`), and:
1. On success: Exits 0 and outputs a machine-readable JSON result on `stdout` describing the sanitization outcome.
2. On operational/validation errors: Exits 1 and outputs a machine-readable JSON error object `{"error": <code\>, "message": ...}` on `stdout` alongside human diagnostics on `stderr`.


</details>
