### PR TITLE
fix: Automated agentic CLI (adeu) bug fix

### DIFF
--- a/python/src/adeu/diff.py
+++ b/python/src/adeu/diff.py
@@ -353,7 +353,7 @@ def _words_to_chars(text1: str, text2: str, atomic_criticmarkup: bool = False) -
     """
     token_array: List[str] = []
     token_hash: Dict[str, int] = {}
-    split_pattern = r"(\s+|\w+|[^\w\s])"
+    split_pattern = r"(\s+|[\$€£¥]\d+(?:,\d{3})*(?:\.\d+)?|\w+|[^\w\s])"
 
     def tokenize(text: str) -> List[str]:
         if not atomic_criticmarkup:

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -29,7 +29,7 @@ from adeu.pagination import paginate, split_structural_appendix
 from adeu.redline.comments import CommentsManager
 from adeu.redline.mapper import DocumentMapper, TextSpan
 from adeu.utils.docx import create_attribute, create_element, strip_bom_from_docx_bytes
-from adeu.utils.safe_regex import RegexTimeoutError
+from adeu.utils.safe_regex import RegexTimeoutError, safe_user_sub
 from adeu.utils.text import PREVIEW_TEXT_CAP, REPORT_ECHO_CAP, truncate_middle
 
 logger = structlog.get_logger(__name__)
@@ -3349,10 +3349,9 @@ class RedlineEngine:
                 continue
 
             if is_regex and current_effective_new_text:
-                try:
-                    current_effective_new_text = re.sub(edit.target_text, current_effective_new_text, actual_doc_text)
-                except re.error:
-                    pass
+                current_effective_new_text = safe_user_sub(
+                    edit.target_text, current_effective_new_text, actual_doc_text
+                )
 
             # Stash the first occurrence's full match for the report preview,
             # so it can show the complete logical change rather than only the

--- a/python/src/adeu/utils/safe_regex.py
+++ b/python/src/adeu/utils/safe_regex.py
@@ -50,9 +50,28 @@ def _translate_error(pattern: str, exc: Exception) -> Exception:
     return exc
 
 
+def escape_currency_regex_target(pattern: str) -> str:
+    """Escapes unescaped dollar signs preceding digits in user regex patterns so
+    currency figures like $100 are matched as literal dollar signs rather than
+    evaluated as end-of-line anchors."""
+    if not pattern:
+        return pattern
+    return _re.sub(r"(?<!\\)\$(\d)", r"\$\1", pattern)
+
+
+def safe_user_sub(pattern: str, repl: str, string: str, flags: int = 0) -> str:
+    """Performs re.sub with currency-safe pattern escaping and literal replacement."""
+    safe_pattern = escape_currency_regex_target(pattern)
+    try:
+        return _re.sub(safe_pattern, repl, string, flags=flags)
+    except _re.error:
+        return repl
+
+
 def user_finditer(pattern: str, text: str, flags: int = 0) -> Iterator["_regex.Match"]:
     """finditer with a wall-clock budget. Materializes matches so the deadline
     covers the entire scan, not just the first match."""
+    pattern = escape_currency_regex_target(pattern)
     try:
         return iter(list(_regex.finditer(pattern, text, flags=flags, timeout=USER_PATTERN_TIMEOUT_SECONDS)))
     except Exception as exc:  # noqa: BLE001 - translated and re-raised
@@ -61,6 +80,7 @@ def user_finditer(pattern: str, text: str, flags: int = 0) -> Iterator["_regex.M
 
 def user_search(pattern: str, text: str, flags: int = 0) -> Optional["_regex.Match"]:
     """search with a wall-clock budget."""
+    pattern = escape_currency_regex_target(pattern)
     try:
         return _regex.search(pattern, text, flags=flags, timeout=USER_PATTERN_TIMEOUT_SECONDS)
     except Exception as exc:  # noqa: BLE001 - translated and re-raised

--- a/python/tests/test_repro_dollar_currency_interpolation.py
+++ b/python/tests/test_repro_dollar_currency_interpolation.py
@@ -1,0 +1,92 @@
+# FILE: tests/test_repro_dollar_currency_interpolation.py
+"""
+Repro tests for Finding 1 in eval_report.md:
+"Regex Backreference Interpolation Corrupts Dollar Amounts and Currency Figures in adeu apply and adeu diff"
+
+Finding summary:
+  Editing documents containing currency amounts / dollar figures ($100, $250,000)
+  must preserve the monetary values ($100, $250,000) without dollar sign stripping
+  or target-not-found failures when processing currency edits.
+"""
+
+from io import BytesIO
+
+from docx import Document
+
+from adeu.diff import generate_structured_edits
+from adeu.ingest import _extract_text_from_doc, extract_text_from_stream
+from adeu.models import ModifyText
+from adeu.redline.engine import RedlineEngine
+
+
+def build_contract_fee_doc(text: str = "The total compensation shall be $100 per hour.") -> BytesIO:
+    d = Document()
+    d.add_paragraph(text)
+    buf = BytesIO()
+    d.save(buf)
+    buf.seek(0)
+    return buf
+
+
+class TestDollarCurrencyInterpolation:
+    def test_apply_currency_edit_with_regex_flag(self):
+        """
+        Applying a regex edit targeting document text containing dollar signs
+        (e.g., 'The total compensation shall be $100 per hour.') with regex=True
+        must match the target string and substitute the new dollar figure ($250,000).
+        """
+        doc_stream = build_contract_fee_doc("The total compensation shall be $100 per hour.")
+        engine = RedlineEngine(doc_stream)
+        edit = ModifyText(
+            type="modify",
+            target_text="The total compensation shall be $100 per hour.",
+            new_text="The total compensation shall be $250,000 per hour.",
+            regex=True,
+        )
+
+        stats = engine.process_batch([edit])
+        assert stats["edits_applied"] == 1, "The currency edit with regex=True must apply"
+
+        out_stream = engine.save_to_stream()
+        clean = extract_text_from_stream(out_stream, clean_view=True)
+        assert "$250,000" in clean, f"Output clean text must contain '$250,000': {clean}"
+
+    def test_apply_currency_edit_preserves_dollar_figures_in_docx(self):
+        """
+        Applying an edit replacing $100 with $250,000 must result in the new
+        dollar figure ($250,000) being directly accessible in paragraph text
+        of the output DOCX document.
+        """
+        doc_stream = build_contract_fee_doc("The total compensation shall be $100 per hour.")
+        engine = RedlineEngine(doc_stream)
+        edit = ModifyText(
+            type="modify",
+            target_text="The total compensation shall be $100 per hour.",
+            new_text="The total compensation shall be $250,000 per hour.",
+        )
+
+        engine.process_batch([edit])
+        out_stream = engine.save_to_stream()
+
+        # Load output docx clean view text via extract_text_from_stream
+        clean_text = extract_text_from_stream(out_stream, clean_view=True)
+        assert "$250,000" in clean_text, f"Output docx clean text must contain '$250,000' (got: {repr(clean_text)})"
+
+    def test_diff_currency_edit_includes_dollar_symbol(self):
+        """
+        adeu diff between a $100 document and $250,000 document must emit
+        a target_text containing '$100' and a new_text containing '$250,000'.
+        """
+        doc1 = build_contract_fee_doc("The total compensation shall be $100 per hour.")
+        doc2 = build_contract_fee_doc("The total compensation shall be $250,000 per hour.")
+
+        doc_o = Document(doc1)
+        doc_m = Document(doc2)
+        text_o, struct_o = _extract_text_from_doc(doc_o, clean_view=True, include_appendix=False, return_structure=True)
+        text_m, struct_m = _extract_text_from_doc(doc_m, clean_view=True, include_appendix=False, return_structure=True)
+        edits, warnings = generate_structured_edits(text_o, struct_o, text_m, struct_m)
+        assert len(edits) == 1, "Should generate exactly 1 edit hunk"
+        edit = edits[0]
+
+        assert "$100" in edit.target_text, f"target_text should include '$100': {edit.target_text}"
+        assert "$250,000" in edit.new_text, f"new_text should include '$250,000': {edit.new_text}"


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[21:49:23] ### Summary of Work
[21:49:23] 
[21:49:23] #### Root Cause Analysis
[21:49:23] The bug where currency figures like `$100` and `$250,000` were corrupted or skipped during `adeu apply` and `adeu diff` had two distinct causes:
[21:49:24] 1. **Regex Pattern Matching (`$`)**: When `is_regex=True`, unescaped `$` signs before numbers in `target_text` (e.g. `"The total compensation shall be $100 per hour."`) were evaluated as regex end-of-line anchors followed by digits. This caused regex matching in `user_search`/`user_finditer` and `re.sub` in [engine.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/redline/engine.py#L3350-L3355) to fail to match the document text.
[21:49:24] 2. **Word Tokenization in Diff**: In [diff.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/diff.py#L356), `_words_to_chars` split `$` and digits into separate tokens. When diffing `"$100"` vs `"$250,000"`, `$` was treated as an `EQUAL` token, stripping `$` from both `target_text` (`"100"`) and `new_text` (`"250,000"`).
[21:49:24] 
[21:49:24] #### Key Changes Implemented
[21:49:24] - **[safe_regex.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/utils/safe_regex.py#L53-L84)**: 
[21:49:24]   - Added `escape_currency_regex_target` helper to automatically escape unescaped `$` preceding digits (e.g. `$100` -> `\$100`) so user regex patterns match literal currency figures instead of end-of-line anchors.
[21:49:24]   - Added `safe_user_sub` helper to execute `re.sub` safely with currency-aware pattern escaping.
[21:49:25]   - Updated `user_search` and `user_finditer` to apply currency pattern escaping.
[21:49:25] - **[engine.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/redline/engine.py#L3351-L3355)**: Replaced raw `re.sub` in `RedlineEngine` with `safe_user_sub`.
[21:49:25] - **[diff.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/diff.py#L356)**: Updated `split_pattern` in `_words_to_chars` to tokenize currency figures (such as `$100`, `$250,000`, `€50`) as single atomic tokens rather than separating the currency symbol from the digits.
[21:49:25] - **[test_repro_dollar_currency_interpolation.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_repro_dollar_currency_interpolation.py#L1-L93)**: Updated regression test assertions to extract clean text from document streams and pass structural projections to `generate_structured_edits`.
[21:49:25] 
[21:49:25] #### Verification
[21:49:25] - Ran `uv run pytest tests/test_repro_dollar_currency_interpolation.py`: All 3 tests passed.
[21:49:25] - Ran full test suite (`uv run pytest`): All 938 tests passed (0 failures).


<details><summary>Reproduction Report</summary>

[21:42:26] I have created the permanent, failing regression test for **Finding 1** ("Regex Backreference Interpolation Corrupts Dollar Amounts and Currency Figures in `adeu apply` and `adeu diff`") in the `adeu` codebase.
[21:42:26] 
[21:42:27] ### Created Regression Test File
[21:42:27] - [test_repro_dollar_currency_interpolation.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_repro_dollar_currency_interpolation.py)
[21:42:27] 
[21:42:27] ### Test Case Overview & Failure Modes Verified
[21:42:27] 1. **`test_apply_currency_edit_with_regex_flag`**:
[21:42:27]    - Asserts that applying a `ModifyText` edit with `regex=True` on a string containing dollar figures (e.g. `"The total compensation shall be $100 per hour."`) matches the target text and replaces it with the new dollar figure (`"$250,000"`).
[21:42:27]    - **Current Status**: Fails with `BatchValidationError: Target text not found in document` because unescaped `$` in `target_text` is evaluated as an end-of-line regex anchor.
[21:42:27] 
[21:42:27] 2. **`test_apply_currency_edit_preserves_dollar_figures_in_docx`**:
[21:42:28]    - Asserts that applying a dollar amount edit (`$100` -> `$250,000`) renders the new dollar figure `$250,000` accessible in the output DOCX document paragraph text.
[21:42:28]    - **Current Status**: Fails with `AssertionError: Output docx paragraph text must contain '$250,000' (got: 'The total compensation shall be $ per hour.')`.
[21:42:28] 
[21:42:28] 3. **`test_diff_currency_edit_includes_dollar_symbol`**:
[21:42:28]    - Asserts that `adeu diff` between a `$100` document and a `$250,000` document emits edit JSON preserving the `$` currency symbol in both `target_text` and `new_text`.
[21:42:28]    - **Current Status**: Fails with `AssertionError: target_text should include '$100': 100`.


</details>
