### PR TITLE
fix: create missing output parent directories in MCP save

### DIFF
--- a/node/packages/mcp-server/src/index.ts
+++ b/node/packages/mcp-server/src/index.ts
@@ -751,6 +751,7 @@ server.registerTool(
         const existedBefore = fs.existsSync(outPath);
         const outBuf = await doc.save();
         try {
+          fs.mkdirSync(dirname(outPath), { recursive: true });
           fs.writeFileSync(outPath, outBuf);
         } catch (e: any) {
           // Filesystem failures (name too long, missing directory, perms)
@@ -828,6 +829,7 @@ server.registerTool(
       const existedBefore = fs.existsSync(outPath);
       const outBuf = await doc.save();
 
+      fs.mkdirSync(dirname(outPath), { recursive: true });
       fs.writeFileSync(outPath, outBuf);
 
       let text: string;
@@ -1013,6 +1015,7 @@ server.registerTool(
 
       if (result.outBuffer) {
         const existedBefore = fs.existsSync(outPath);
+        fs.mkdirSync(dirname(outPath), { recursive: true });
         fs.writeFileSync(outPath, result.outBuffer);
         const note = overwriteNote(outPath, file_path, existedBefore);
         return {

--- a/node/packages/mcp-server/src/mcp.bugs.test.ts
+++ b/node/packages/mcp-server/src/mcp.bugs.test.ts
@@ -279,5 +279,42 @@ describe("Resolved Bugs MCP Server Verification", () => {
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain("Page -1 out of range");
   });
+
+  it("creates non-existent output parent directory when saving batch results", async () => {
+    const nestedOutPath = join(
+      tmpdir(),
+      `adeu_test_dir_${Date.now()}`,
+      "sub_dir",
+      `adeu_out_${Date.now()}.docx`,
+    );
+
+    const res = await sendRpc(
+      "tools/call",
+      {
+        name: "process_document_batch",
+        arguments: {
+          reasoning: "test non-existent directory creation",
+          original_docx_path: cleanDocPath,
+          author_name: "Agent",
+          output_path: nestedOutPath,
+          changes: [
+            {
+              type: "modify",
+              target_text: "document",
+              new_text: "updated document",
+            },
+          ],
+        },
+      },
+      115,
+    );
+
+    expect(res.result.isError).toBeUndefined();
+    expect(res.result.content[0].text).toContain("Batch complete.");
+    expect(existsSync(nestedOutPath)).toBe(true);
+
+    if (existsSync(nestedOutPath)) unlinkSync(nestedOutPath);
+  });
 });
+
 

--- a/python/src/adeu/mcp_components/shared.py
+++ b/python/src/adeu/mcp_components/shared.py
@@ -151,5 +151,8 @@ def add_timing_if_debug(start_time: float, result: Any) -> Any:
 
 
 def save_stream(stream: BytesIO, path: str):
-    with open(path, "wb") as f:
+    p = Path(path)
+    if p.parent and str(p.parent) not in ("", "."):
+        p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "wb") as f:
         f.write(stream.getvalue())

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -822,3 +822,48 @@ def test_read_docx_appendix_mode_schema_compat(tmp_path):
 
     # Assert that the result was successful and contains appendix information
     assert "Agreement" in text
+
+
+def test_process_document_batch_nonexistent_output_parent_directory(tmp_path):
+    """
+    Verifies that process_document_batch automatically creates missing parent
+    directories for output_path when saving batch results, rather than crashing
+    with an unhandled FileNotFoundError ([Errno 2] No such file or directory).
+    """
+    import asyncio
+    from unittest.mock import patch
+
+    import docx
+
+    from adeu.server import mcp
+
+    # Create a minimal document
+    doc_path = tmp_path / "sample.docx"
+    doc = docx.Document()
+    doc.add_paragraph("The quick brown fox jumps over the lazy dog.")
+    doc.save(str(doc_path))
+
+    # Specify output_path in a non-existent parent directory
+    output_dir = tmp_path / "nested_folder" / "sub_folder"
+    output_path = output_dir / "output.docx"
+
+    arguments = {
+        "reasoning": "Save batch output to a new nested directory path",
+        "original_docx_path": str(doc_path),
+        "author_name": "Test Author",
+        "output_path": str(output_path),
+        "changes": [{"type": "modify", "target_text": "fox", "new_text": "wolf"}],
+    }
+
+    with (
+        patch("fastmcp.server.context.Context.info"),
+        patch("fastmcp.server.context.Context.debug"),
+        patch("fastmcp.server.context.Context.warning"),
+        patch("fastmcp.server.context.Context.error"),
+    ):
+        result = asyncio.run(mcp.call_tool("process_document_batch", arguments))
+
+    text = "".join(item.text for item in result.content if item.type == "text")
+
+    assert "Batch complete" in text, f"Expected batch to complete successfully, got: {text}"
+    assert output_path.exists(), f"Output file was not created at {output_path}"


### PR DESCRIPTION
## Agentic Auto-Fix (MCP (python))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
When `process_document_batch` or `accept_all_changes` was called with an `output_path` located in a non-existent parent directory (e.g., `nested_folder/sub_folder/output.docx`), `save_stream()` in `adeu.mcp_components.shared` executed `open(path, "wb")` directly without creating the parent directories first. This caused Python to raise `FileNotFoundError: [Errno 2] No such file or directory`, halting batch completion and returning an unhandled file system error.

### The Fix
1. **Python MCP Shared Layer (`python/src/adeu/mcp_components/shared.py`)**:
   Updated `save_stream(stream, path)` to invoke `p.parent.mkdir(parents=True, exist_ok=True)` before opening the file handle for writing. `save_stream` is the single centralized output-persisting helper for MCP document tools on Python.
2. **Node MCP Server (`node/packages/mcp-server/src/index.ts`)**:
   Added `fs.mkdirSync(dirname(outPath), { recursive: true });` before `fs.writeFileSync` in `process_document_batch`, `accept_all_changes`, and `sanitize_docx` tool handlers to maintain backend parity.

### Sibling Occurrences
- **Python CLI & Sanitize Core**: Verified that `_write_output_or_exit` in `adeu/cli.py` and `_atomic_write` in `adeu/sanitize/core.py` already create parent directories via `mkdir(parents=True, exist_ok=True)`.
- **LangChain Tools**: Verified that `langchain_adeu` tools already create output parent directories prior to writing.
- **Node MCP Server**: Identified that `index.ts` had three `fs.writeFileSync` calls without prior `mkdirSync`. Fixed all three sites (`process_document_batch`, `accept_all_changes`, and `sanitize_docx`).

### Verification
- **Python Regression Test**: `uv run pytest tests/test_cli_bug_repro.py::test_process_document_batch_nonexistent_output_parent_directory` passed.
- **Full Python Test Suite**: `uv run pytest` passed cleanly (948 passed, 39 skipped).
- **Python Formatting & Linting**: `uv run ruff check --fix .` and `uv run ruff format .` passed with 0 errors.
- **Python Static Type Check**: `uv run mypy src` passed with 0 errors across 30 source files.
- **Node Package Build & Tests**: `npm install && npm run build && npm test` succeeded across all workspaces (406 core unit tests passed, 70 mcp-server tests passed including new vitest coverage in `mcp.bugs.test.ts`, 23 n8n node tests passed).

### Risk Assessment & Follow-ups
- **Risk**: Very low. Automatically creating parent directories for explicit output paths matches user expectations and existing CLI/LangChain behavior.
- **Follow-up**: Ensure any new file-writing entry points in future tools route through `save_stream` or `_atomic_write` to guarantee directory creation and safe file handling.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/mcp_py_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
**Severity:** S2 (Workflow Failure / Unhandled Exception)
**Bug:** `process_document_batch` Crashes with Unhandled `[Errno 2]` When `output_path` Parent Directory Does Not Exist.
When `process_document_batch` (or `_process_document_batch_disk`) is called with an `output_path` that specifies a non-existent parent directory (e.g. `nested_folder/sub_folder/output.docx`), `save_stream` attempts to open the file handle via `open(path, "wb")` directly without creating missing parent directories first. This causes Python to raise an unhandled `FileNotFoundError: [Errno 2] No such file or directory`, causing the batch execution to crash and return an error message rather than creating the parent directories and saving the file. Note on bug selection: The "Top Bug" from `eval_report.md` regarding `sanitize_docx` error string formatting specifiers (`%!o(MISSING)`) was verified to be already fixed in commit `6e195e6` and covered by `test_repro_sanitize_double_percent_escaping`, so this S2 defect was selected as the actionable open bug.

### Minimal Reproduction
**Minimal Input Document Recipe:**
```python
import docx
doc = docx.Document()
doc.add_paragraph("The quick brown fox jumps over the lazy dog.")
doc.save("input.docx")
```

**Minimal Execution Script (from scratch experiment):**
```python
import asyncio
from pathlib import Path
from unittest.mock import AsyncMock
from fastmcp import Context
from adeu.mcp_components.tools.document import _process_document_batch_disk
from adeu.models import ModifyText

doc_path = Path("input.docx")
output_path = Path("non_existent_subdir/output.docx")
ctx = AsyncMock(spec=Context)

async def main():
    result = await _process_document_batch_disk(
        original_docx_path=str(doc_path),
        author_name="Test Author",
        ctx=ctx,
        changes=[ModifyText(target_text="fox", new_text="wolf")],
        output_path=str(output_path),
    )
    print("RESULT:", result)

asyncio.run(main())
```

**Observed Scratch Output:**
```
RESULT: Error processing batch: [Errno 2] No such file or directory: 'non_existent_subdir/output.docx'
```

### Full Test Code
Added to `/Users/mkorpela/workspace/agy-loop/workspaces/mcp_py_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py`:

```python
def test_process_document_batch_nonexistent_output_parent_directory(tmp_path):
    """
    Verifies that process_document_batch automatically creates missing parent
    directories for output_path when saving batch results, rather than crashing
    with an unhandled FileNotFoundError ([Errno 2] No such file or directory).
    """
    import asyncio
    from unittest.mock import patch

    import docx

    from adeu.server import mcp

    # Create a minimal document
    doc_path = tmp_path / "sample.docx"
    doc = docx.Document()
    doc.add_paragraph("The quick brown fox jumps over the lazy dog.")
    doc.save(str(doc_path))

    # Specify output_path in a non-existent parent directory
    output_dir = tmp_path / "nested_folder" / "sub_folder"
    output_path = output_dir / "output.docx"

    arguments = {
        "reasoning": "Save batch output to a new nested directory path",
        "original_docx_path": str(doc_path),
        "author_name": "Test Author",
        "output_path": str(output_path),
        "changes": [{"type": "modify", "target_text": "fox", "new_text": "wolf"}],
    }

    with (
        patch("fastmcp.server.context.Context.info"),
        patch("fastmcp.server.context.Context.debug"),
        patch("fastmcp.server.context.Context.warning"),
        patch("fastmcp.server.context.Context.error"),
    ):
        result = asyncio.run(mcp.call_tool("process_document_batch", arguments))

    text = "".join(item.text for item in result.content if item.type == "text")

    assert "Batch complete" in text, f"Expected batch to complete successfully, got: {text}"
    assert output_path.exists(), f"Output file was not created at {output_path}"
```

### Pytest Failure Output
```
=================================== FAILURES ===================================
_______ test_process_document_batch_nonexistent_output_parent_directory ________
[gw0] darwin -- Python 3.13.12 /Users/mkorpela/workspace/agy-loop/workspaces/mcp_py_reproduce/adeu_isolated/python/.venv/bin/python

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-36/popen-gw0/test_process_document_batch_no0')

    def test_process_document_batch_nonexistent_output_parent_directory(tmp_path):
        """
        Verifies that process_document_batch automatically creates missing parent
        directories for output_path when saving batch results, rather than crashing
        with an unhandled FileNotFoundError ([Errno 2] No such file or directory).
        """
        import asyncio
        from unittest.mock import patch
    
        import docx
    
        from adeu.server import mcp
    
        # Create a minimal document
        doc_path = tmp_path / "sample.docx"
        doc = docx.Document()
        doc.add_paragraph("The quick brown fox jumps over the lazy dog.")
        doc.save(str(doc_path))
    
        # Specify output_path in a non-existent parent directory
        output_dir = tmp_path / "nested_folder" / "sub_folder"
        output_path = output_dir / "output.docx"
    
        arguments = {
            "reasoning": "Save batch output to a new nested directory path",
            "original_docx_path": str(doc_path),
            "author_name": "Test Author",
            "output_path": str(output_path),
            "changes": [{"type": "modify", "target_text": "fox", "new_text": "wolf"}],
        }
    
        with (
            patch("fastmcp.server.context.Context.info"),
            patch("fastmcp.server.context.Context.debug"),
            patch("fastmcp.server.context.Context.warning"),
            patch("fastmcp.server.context.Context.error"),
        ):
            result = asyncio.run(mcp.call_tool("process_document_batch", arguments))
    
        text = "".join(item.text for item in result.content if item.type == "text")
    
>       assert "Batch complete" in text, f"Expected batch to complete successfully, got: {text}"
E       AssertionError: Expected batch to complete successfully, got: Error processing batch: [Errno 2] No such file or directory: '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-36/popen-gw0/test_process_document_batch_no0/nested_folder/sub_folder/output.docx'
E       assert 'Batch complete' in "Error processing batch: [Errno 2] No such file or directory: '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-36/popen-gw0/test_process_document_batch_no0/nested_folder/sub_folder/output.docx'"

tests/test_cli_bug_repro.py:868: AssertionError
```

### Expected Behavior Once Fixed
When `process_document_batch` (and `save_stream` in `adeu.mcp_components.shared`) receives an `output_path` in a non-existent parent directory, it should automatically create all missing parent directories (`Path(path).parent.mkdir(parents=True, exist_ok=True)`) before writing the file stream to disk. The batch operation should report success ("Batch complete. Saved to: ...") and the output document file should exist at `output_path`.


</details>
