### PR TITLE
fix: Automated agentic CLI (adeu) bug fix

### DIFF
--- a/node/packages/core/src/engine.ts
+++ b/node/packages/core/src/engine.ts
@@ -3740,21 +3740,20 @@ export class RedlineEngine {
       if (typeof edit !== "object" || edit === null) continue;
 
       if (
-        edit._resolved_start_idx !== undefined &&
-        edit._resolved_start_idx !== null
+        (edit._resolved_start_idx !== undefined &&
+          edit._resolved_start_idx !== null) ||
+        (edit._match_start_index !== undefined &&
+          edit._match_start_index !== null)
       ) {
-        if (!edit._active_mapper_ref) {
-          if (!this.clean_mapper) {
-            this.clean_mapper = new DocumentMapper(this.doc, true);
-          }
-          edit._active_mapper_ref = this.clean_mapper;
+        if (
+          edit._resolved_start_idx === undefined ||
+          edit._resolved_start_idx === null
+        ) {
+          edit._resolved_start_idx = edit._match_start_index;
         }
-        resolved_edits.push([edit, edit.new_text || null]);
-      } else if (
-        edit._match_start_index !== undefined &&
-        edit._match_start_index !== null
-      ) {
-        edit._resolved_start_idx = edit._match_start_index;
+        // Caller-pinned indices (diff output) are CLEAN-view character
+        // offsets; the raw-view mapper fallback would mis-anchor them on
+        // documents whose views differ (AP-05).
         if (!edit._active_mapper_ref) {
           if (!this.clean_mapper) {
             this.clean_mapper = new DocumentMapper(this.doc, true);

--- a/node/packages/core/src/engine.ts
+++ b/node/packages/core/src/engine.ts
@@ -3743,12 +3743,24 @@ export class RedlineEngine {
         edit._resolved_start_idx !== undefined &&
         edit._resolved_start_idx !== null
       ) {
+        if (!edit._active_mapper_ref) {
+          if (!this.clean_mapper) {
+            this.clean_mapper = new DocumentMapper(this.doc, true);
+          }
+          edit._active_mapper_ref = this.clean_mapper;
+        }
         resolved_edits.push([edit, edit.new_text || null]);
       } else if (
         edit._match_start_index !== undefined &&
         edit._match_start_index !== null
       ) {
         edit._resolved_start_idx = edit._match_start_index;
+        if (!edit._active_mapper_ref) {
+          if (!this.clean_mapper) {
+            this.clean_mapper = new DocumentMapper(this.doc, true);
+          }
+          edit._active_mapper_ref = this.clean_mapper;
+        }
         resolved_edits.push([edit, edit.new_text || null]);
       } else if (edit.type === "insert_row" || edit.type === "delete_row") {
         let matches = this.mapper.drop_virtual_only_matches(

--- a/node/packages/core/src/repro.pinned-index-clean-mapper.test.ts
+++ b/node/packages/core/src/repro.pinned-index-clean-mapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DocumentObject } from "./docx/bridge.js";
+import { RedlineEngine } from "./engine.js";
+import { extractTextFromBuffer } from "./ingest.js";
+import { generate_edits_via_paragraph_alignment } from "./diff.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Reproduction for AP-05 (mirrors the Python regression test in
+// python/tests/test_cli_bug_repro.py):
+// Diff-generated edits carry _match_start_index pinned into the CLEAN-view
+// text the diff was computed against. apply_edits' pre-resolve phase used to
+// leave _active_mapper_ref unset for pinned edits, so dispatch fell back to
+// the RAW-view mapper. On a document whose views differ (tracked changes,
+// comments), the clean-view offset lands on the wrong runs, insertions
+// degrade to the paragraph-start fallback, and the applied text reads
+// "MODIFIEDTyping some..." instead of "...Typing some text MODIFIED".
+// The fix binds pinned edits to the initial clean-view mapper.
+describe("Pinned-index edits bind to the clean-view mapper", () => {
+  it("round-trips a clean-view diff apply on a tracked-changes document (dirty_sample.docx)", async () => {
+    const fixturePath = resolve(
+      __dirname,
+      "../../../../shared/fixtures/dirty_sample.docx",
+    );
+    const buf = readFileSync(fixturePath);
+
+    // Canonical apply baseline: the CLEAN (accepted) view, no appendix —
+    // the same text the CLI diffs a user's modified text file against.
+    const text_orig = await extractTextFromBuffer(buf, true, false);
+    expect(text_orig).toContain("Typing some text");
+
+    const text_mod = text_orig.replaceAll(
+      "Typing some text",
+      "Typing some text MODIFIED",
+    );
+
+    const edits = generate_edits_via_paragraph_alignment(text_orig, text_mod);
+    expect(edits.length).toBeGreaterThan(0);
+
+    const doc = await DocumentObject.load(buf);
+    const engine = new RedlineEngine(doc, "T");
+    const stats = engine.process_batch(edits);
+    expect(stats.edits_skipped).toBe(0);
+    expect(stats.edits_applied).toBeGreaterThan(0);
+
+    const out = await doc.save();
+    const clean = await extractTextFromBuffer(out, true, false);
+
+    // The post-apply verification contract: the accepted view of the applied
+    // document reads exactly as the supplied text.
+    expect(clean.trim()).toBe(text_mod.trim());
+
+    // The specific raw-mapper failure mode: the insertion dropped at the
+    // paragraph start instead of after its anchor.
+    expect(clean).toContain("Typing some text MODIFIED");
+    expect(clean).not.toContain("MODIFIEDTyping");
+  });
+});

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -2769,9 +2769,17 @@ class RedlineEngine:
         # Pre-resolve phase: locate all edits against initial clean state
         for edit in edits:
             if edit._resolved_start_idx is not None:
+                if edit._active_mapper_ref is None:
+                    if not self.clean_mapper:
+                        self.clean_mapper = DocumentMapper(self.doc, clean_view=True)
+                    edit._active_mapper_ref = self.clean_mapper
                 resolved_edits.append((edit, getattr(edit, "new_text", None)))
             elif edit._match_start_index is not None:
                 edit._resolved_start_idx = edit._match_start_index
+                if edit._active_mapper_ref is None:
+                    if not self.clean_mapper:
+                        self.clean_mapper = DocumentMapper(self.doc, clean_view=True)
+                    edit._active_mapper_ref = self.clean_mapper
                 resolved_edits.append((edit, getattr(edit, "new_text", None)))
             elif isinstance(edit, (InsertTableRow, DeleteTableRow)):
                 # Simplified resolution for structural edits

--- a/python/src/adeu/redline/engine.py
+++ b/python/src/adeu/redline/engine.py
@@ -2768,14 +2768,12 @@ class RedlineEngine:
 
         # Pre-resolve phase: locate all edits against initial clean state
         for edit in edits:
-            if edit._resolved_start_idx is not None:
-                if edit._active_mapper_ref is None:
-                    if not self.clean_mapper:
-                        self.clean_mapper = DocumentMapper(self.doc, clean_view=True)
-                    edit._active_mapper_ref = self.clean_mapper
-                resolved_edits.append((edit, getattr(edit, "new_text", None)))
-            elif edit._match_start_index is not None:
-                edit._resolved_start_idx = edit._match_start_index
+            if edit._resolved_start_idx is not None or edit._match_start_index is not None:
+                if edit._resolved_start_idx is None:
+                    edit._resolved_start_idx = edit._match_start_index
+                # Caller-pinned indices (diff output) are CLEAN-view character
+                # offsets; the raw-view mapper fallback would mis-anchor them
+                # on documents whose views differ (AP-05).
                 if edit._active_mapper_ref is None:
                     if not self.clean_mapper:
                         self.clean_mapper = DocumentMapper(self.doc, clean_view=True)

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -869,7 +869,7 @@ def test_process_document_batch_nonexistent_output_parent_directory(tmp_path):
     assert output_path.exists(), f"Output file was not created at {output_path}"
 
 
-def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
+def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path, capsys):
     """
     Regression test for AP-05:
     Full text-file apply verification failure & paragraph collapse.
@@ -882,23 +882,8 @@ def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
     """
     import re
     import shutil
-    import sys
-    from pathlib import Path
-    from unittest.mock import patch
 
-    import docx
-
-    from adeu.cli import main
     from adeu.ingest import _extract_text_from_doc
-
-    def run_cli(args):
-        code = 0
-        with patch.object(sys, "argv", ["adeu"] + [str(a) for a in args]):
-            try:
-                main()
-            except SystemExit as e:
-                code = e.code or 0
-        return code
 
     # Copy dirty_sample.docx fixture to tmp_path
     fixture_path = Path(__file__).parent.parent.parent / "shared" / "fixtures" / "dirty_sample.docx"
@@ -908,7 +893,8 @@ def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
     # 1. Extract clean-view text
     extracted_txt_path = tmp_path / "extracted.txt"
     extract_args = ["extract", "--clean-view", "--page", "all", str(doc_path), "-o", str(extracted_txt_path)]
-    assert run_cli(extract_args) == 0
+    code, _, _ = run_cli(extract_args, capsys)
+    assert code == 0
 
     # 2. Modify the extracted text file
     text = extracted_txt_path.read_text(encoding="utf-8")
@@ -920,10 +906,10 @@ def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
     # 3. Apply the modified text file
     output_docx_path = tmp_path / "output.docx"
     apply_args = ["apply", str(doc_path), str(modified_txt_path), "-o", str(output_docx_path)]
-    exit_code = run_cli(apply_args)
+    exit_code, _, stderr = run_cli(apply_args, capsys)
 
     # Verification: adeu apply should succeed with exit code 0 and create output.docx
-    assert exit_code == 0, f"adeu apply failed with exit code {exit_code}"
+    assert exit_code == 0, f"adeu apply failed with exit code {exit_code}\nSTDERR:\n{stderr}"
     assert output_docx_path.exists(), "output.docx was not created"
 
     # 4. Verify clean-view text of output document matches modified text

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -867,3 +867,70 @@ def test_process_document_batch_nonexistent_output_parent_directory(tmp_path):
 
     assert "Batch complete" in text, f"Expected batch to complete successfully, got: {text}"
     assert output_path.exists(), f"Output file was not created at {output_path}"
+
+
+def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
+    """
+    Regression test for AP-05:
+    Full text-file apply verification failure & paragraph collapse.
+
+    When extracting clean text from a document with tracked changes or comments
+    and applying a modified version of that text back to the document via `adeu apply`,
+    the engine must correctly map clean-view character offsets so that edits are
+    anchored to the proper text runs rather than falling back to index 0/1 of the paragraph,
+    which collapses paragraph structure and fails post-apply verification.
+    """
+    import re
+    import shutil
+    import sys
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import docx
+
+    from adeu.cli import main
+    from adeu.ingest import _extract_text_from_doc
+
+    def run_cli(args):
+        code = 0
+        with patch.object(sys, "argv", ["adeu"] + [str(a) for a in args]):
+            try:
+                main()
+            except SystemExit as e:
+                code = e.code or 0
+        return code
+
+    # Copy dirty_sample.docx fixture to tmp_path
+    fixture_path = Path(__file__).parent.parent.parent / "shared" / "fixtures" / "dirty_sample.docx"
+    doc_path = tmp_path / "input.docx"
+    shutil.copy(fixture_path, doc_path)
+
+    # 1. Extract clean-view text
+    extracted_txt_path = tmp_path / "extracted.txt"
+    extract_args = ["extract", "--clean-view", "--page", "all", str(doc_path), "-o", str(extracted_txt_path)]
+    assert run_cli(extract_args) == 0
+
+    # 2. Modify the extracted text file
+    text = extracted_txt_path.read_text(encoding="utf-8")
+    assert "Typing some text" in text
+    modified_text = text.replace("Typing some text", "Typing some text MODIFIED")
+    modified_txt_path = tmp_path / "modified.txt"
+    modified_txt_path.write_text(modified_text, encoding="utf-8")
+
+    # 3. Apply the modified text file
+    output_docx_path = tmp_path / "output.docx"
+    apply_args = ["apply", str(doc_path), str(modified_txt_path), "-o", str(output_docx_path)]
+    exit_code = run_cli(apply_args)
+
+    # Verification: adeu apply should succeed with exit code 0 and create output.docx
+    assert exit_code == 0, f"adeu apply failed with exit code {exit_code}"
+    assert output_docx_path.exists(), "output.docx was not created"
+
+    # 4. Verify clean-view text of output document matches modified text
+    out_doc = docx.Document(output_docx_path)
+    out_text = _extract_text_from_doc(out_doc, clean_view=True, include_appendix=False)
+
+    expected_text = modified_txt_path.read_text(encoding="utf-8")
+    expected_text_clean = re.sub(r"^>\s*\*\*File Path:\*\*.*?\n\n?", "", expected_text, count=1).strip()
+
+    assert out_text.strip() == expected_text_clean

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -927,7 +927,7 @@ def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
     assert output_docx_path.exists(), "output.docx was not created"
 
     # 4. Verify clean-view text of output document matches modified text
-    out_doc = docx.Document(output_docx_path)
+    out_doc = docx.Document(str(output_docx_path))
     out_text = _extract_text_from_doc(out_doc, clean_view=True, include_appendix=False)
 
     expected_text = modified_txt_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[11:34:49] <gmsg tag="task_status" task_id="5524d224-1fa5-41e3-b185-b0bbb1f9711e/task-102" status="completed" exit_code="0">
[11:34:49] Task 5524d224-1fa5-41e3-b185-b0bbb1f9711e/task-102 completed with exit code 0.
[11:34:49] Stdout:
[11:34:49] ============================= test session starts ==============================
[11:34:49] platform darwin -- Python 3.13.12, pytest-9.1.1, pluggy-1.6.0
[11:34:49] rootdir: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python
[11:34:49] configfile: pyproject.toml
[11:34:49] testpaths: tests
[11:34:50] plugins: cov-7.1.0, xdist-3.8.0, anyio-4.14.2, hypothesis-6.156.6
[11:34:50] created: 4/4 workers
[11:34:50] 4 workers [987 items]
[11:34:50] 
[11:34:50] ........................................................................ [  7%]
[11:34:50] ........................................................................ [ 14%]
[11:34:50] ........................................................................ [ 21%]
[11:34:50] ........................................................................ [ 29%]
[11:34:50] ........................................................................ [ 36%]
[11:34:50] ........................................................................ [ 43%]
[11:34:50] ........................................................................ [ 51%]
[11:34:51] ........................................................................ [ 58%]
[11:34:51] ........................................................................ [ 65%]
[11:34:51] ........................................................................ [ 72%]
[11:34:51] ........................................................................ [ 80%]
[11:34:51] ........................................................................ [ 87%]
[11:34:51] ........................................................................ [ 94%]
[11:34:51] ...................................................                      [100%]
[11:34:51] ============================== 987 passed in 15.60s ============================
[11:34:51] </gmsg>
[11:34:51] 
[11:34:53] ### Summary of Bug Fix (AP-05)
[11:34:53] 
[11:34:53] #### 1. Root Cause Analysis
[11:34:53] - **Problem**: When applying modified full-text files using `adeu apply`, `generate_edits_via_paragraph_alignment` diffed clean-view text extracted with `clean_view=True` and generated `ModifyText` objects with clean-view character offsets (`_match_start_index`).
[11:34:53] - **Mechanism**:
[11:34:53]   - In `engine.apply_edits`, during the pre-resolve phase, `edit._resolved_start_idx` was assigned from `edit._match_start_index`. However, `edit._active_mapper_ref` was left set to `None`.
[11:34:53]   - At apply time (`_apply_single_edit_indexed`), `active_mapper` defaulted to `self.mapper` (the full raw view mapper containing CriticMarkup tags, tracked deletions, and metadata).
[11:34:54]   - Evaluating clean-view character offsets against raw-view mapper spans caused coordinate misalignment. In documents with raw markup, `get_insertion_anchor` failed to find a valid `anchor_run`, returning `(None, <Paragraph>)`.
[11:34:54]   - `_apply_single_edit_indexed` then fell back to inserting text at `index=1` (paragraph start, post-`<w:pPr>`), corrupting paragraph layout/text order and triggering `Post-apply verification failed`.
[11:34:54] 
[11:34:54] #### 2. Key Code Changes
[11:34:54] - **Python Resolution Engine** ([python/src/adeu/redline/engine.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/redline/engine.py#L2769-L2785)):
[11:34:54]   - Updated the pre-resolve phase in `apply_edits` so that when an edit has a caller-pinned `_match_start_index` or `_resolved_start_idx` and `_active_mapper_ref` is `None`, `_active_mapper_ref` is explicitly bound to `self.clean_mapper`.
[11:34:54] - **Node/TS Engine Parity** ([node/packages/core/src/engine.ts](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/node/packages/core/src/engine.ts#L3743-L3756)):
[11:34:55]   - Mirrored the pre-resolve clean mapper binding logic in the Node engine to ensure dual-engine parity.
[11:34:55] - **Regression Test** ([python/tests/test_cli_bug_repro.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py)):
[11:34:55]   - Added `test_repro_text_apply_paragraph_preservation_and_verification` asserting that full-text application on a document with existing tracked changes preserves paragraph layout and passes post-apply verification.
[11:34:55] 
[11:34:55] #### 3. Verification Results
[11:34:55] - **Regression Test**: Passed (`uv run pytest tests/test_cli_bug_repro.py::test_repro_text_apply_paragraph_preservation_and_verification`)
[11:34:55] - **LibreOffice Loadability Test**: Passed (`uv run pytest tests/test_repro_qa_2026_07_18.py::TestC1FooterBoundary::test_applied_output_loads_in_libreoffice`)
[11:34:55] - **Full Test Suite**: Passed (`948 passed, 39 skipped` in `16.57s`).


<details><summary>Reproduction Report</summary>

[11:30:17] I have reproduced bug **AP-05** ("Full Text-File Apply Verification Failure & Paragraph Collapse"), isolated its root cause down to the XML anchor mapping logic, and created a permanent, failing regression test in the test suite.
[11:30:17] 
[11:30:17] ---
[11:30:17] 
[11:30:17] ### Root Cause Analysis
[11:30:17] 
[11:30:17] 1. **Clean-View vs. Full-View Coordinate Mismatch**:
[11:30:17]    - When `adeu apply` processes a modified text file, `generate_edits_via_paragraph_alignment` diffs the clean-view text (`_extract_text_from_doc(doc, clean_view=True)`) and outputs `ModifyText` objects with `_match_start_index` pinned to **clean-view character offsets**.
[11:30:18]    - When `engine.apply_edits` runs on these edits, `edit._resolved_start_idx` is assigned `edit._match_start_index`, but `edit._active_mapper_ref` is not bound to `self.clean_mapper`.
[11:30:18]    - As a result, `_apply_single_edit_indexed` falls back to `self.mapper` (the **full-view mapper**, which includes CriticMarkup annotations `{==`, `{--`, `{++`, `{>>` and comment metadata).
[11:30:18] 
[11:30:18] 2. **Anchor Resolution Failure**:
[11:30:18]    - In the full-view mapper, the clean-view character index lands on virtual CriticMarkup tokens or metadata spans where `run` and `paragraph` are `None`.
[11:30:18]    - `get_insertion_anchor` fails to resolve a valid `anchor_run`, returning `(None, <Paragraph>)`.
[11:30:18] 
[11:30:18] 3. **Fallback Insertion at Paragraph Start**:
[11:30:18]    - When `anchor_run` is `None` and `start_idx != 0`, `_apply_single_edit_indexed` defaults to inserting the element at `index = 1` of the paragraph (immediately after `<w:pPr>`).
[11:30:19]    - The inserted text is prepended to the start of the paragraph rather than attached at the intended text location, corrupting text order (e.g. `MODIFIEDTyping...` instead of `Typing...MODIFIED`) and triggering `Post-apply verification failed`.
[11:30:19] 
[11:30:19] ---
[11:30:19] 
[11:30:19] ### Permanent Regression Test
[11:30:19] 
[11:30:19] Added `test_repro_text_apply_paragraph_preservation_and_verification` to [python/tests/test_cli_bug_repro.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py#L828-L879):
[11:30:19] 
[11:30:19] ```python
[11:30:19] def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path):
[11:30:19]     """
[11:30:19]     Regression test for AP-05:
[11:30:19]     Full text-file apply verification failure & paragraph collapse.
[11:30:19]     """
[11:30:19]     import shutil
[11:30:19]     import re
[11:30:19]     import sys
[11:30:19]     from pathlib import Path
[11:30:19]     from unittest.mock import patch
[11:30:19]     import docx
[11:30:19] 
[11:30:19]     from adeu.cli import main
[11:30:19]     from adeu.ingest import _extract_text_from_doc
[11:30:19] 
[11:30:19]     def run_cli(args):
[11:30:19]         code = 0
[11:30:20]         with patch.object(sys, "argv", ["adeu"] + [str(a) for a in args]):
[11:30:20]             try:
[11:30:20]                 main()
[11:30:20]             except SystemExit as e:
[11:30:20]                 code = e.code or 0
[11:30:20]         return code
[11:30:20] 
[11:30:20]     # Copy dirty_sample.docx fixture to tmp_path
[11:30:20]     fixture_path = Path(__file__).parent.parent.parent / "shared" / "fixtures" / "dirty_sample.docx"
[11:30:20]     doc_path = tmp_path / "input.docx"
[11:30:20]     shutil.copy(fixture_path, doc_path)
[11:30:20] 
[11:30:20]     # 1. Extract clean-view text
[11:30:20]     extracted_txt_path = tmp_path / "extracted.txt"
[11:30:20]     extract_args = ["extract", "--clean-view", "--page", "all", str(doc_path), "-o", str(extracted_txt_path)]
[11:30:20]     assert run_cli(extract_args) == 0
[11:30:20] 
[11:30:20]     # 2. Modify the extracted text file
[11:30:20]     text = extracted_txt_path.read_text(encoding="utf-8")
[11:30:20]     assert "Typing some text" in text
[11:30:20]     modified_text = text.replace("Typing some text", "Typing some text MODIFIED")
[11:30:20]     modified_txt_path = tmp_path / "modified.txt"
[11:30:20]     modified_txt_path.write_text(modified_text, encoding="utf-8")
[11:30:20] 
[11:30:21]     # 3. Apply the modified text file
[11:30:21]     output_docx_path = tmp_path / "output.docx"
[11:30:21]     apply_args = ["apply", str(doc_path), str(modified_txt_path), "-o", str(output_docx_path)]
[11:30:21]     exit_code = run_cli(apply_args)
[11:30:21] 
[11:30:21]     # Verification: adeu apply should succeed with exit code 0 and create output.docx
[11:30:21]     assert exit_code == 0, f"adeu apply failed with exit code {exit_code}"
[11:30:21]     assert output_docx_path.exists(), "output.docx was not created"
[11:30:21] 
[11:30:21]     # 4. Verify clean-view text of output document matches modified text
[11:30:21]     out_doc = docx.Document(output_docx_path)
[11:30:21]     out_text = _extract_text_from_doc(out_doc, clean_view=True, include_appendix=False)
[11:30:21] 
[11:30:21]     expected_text = modified_txt_path.read_text(encoding="utf-8")
[11:30:21]     expected_text_clean = re.sub(r"^>\s*\*\*File Path:\*\*.*?\n\n?", "", expected_text, count=1).strip()
[11:30:21] 
[11:30:21]     assert out_text.strip() == expected_text_clean
[11:30:21] ```
[11:30:21] 
[11:30:21] ---
[11:30:21] 
[11:30:21] ### Test Execution Result
[11:30:21] 
[11:30:21] Running `uv run pytest python/tests/test_cli_bug_repro.py`:
[11:30:21] - **17 passed**, **1 failed** (`test_repro_text_apply_paragraph_preservation_and_verification`).
[11:30:21] - Failure output captures the exact bug behavior:
[11:30:21]   ```text
[11:30:21]   ❌ Post-apply verification failed: the applied document's clean text does not match the supplied text
[11:30:21]   (first divergence at character 0: applied reads 'MODIFIEDTyping some. Typing some text...',
[11:30:21]    supplied text reads 'Typing some. Typing some text MODIFIED...')
[11:30:21]   ```


</details>
