### PR TITLE
fix: write report file on blocked single-file sanitize runs

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1491,9 +1491,12 @@ def handle_sanitize(args: argparse.Namespace):
             print(f"✅ Sanitized → {output_path}", file=sys.stderr)
 
         except SanitizeError as e:
+            # Block reason goes to stderr BEFORE the report write: if the
+            # report path turns out unwritable, _write_report_file exits the
+            # process and the reason would otherwise be lost.
+            print(str(e), file=sys.stderr)
             if args.report_file:
                 _write_report_file(args.report_file, str(e))
-            print(str(e), file=sys.stderr)
             sys.exit(1)
         except FileNotFoundError as e:
             _cli_error("file_not_found", str(e))

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1491,6 +1491,8 @@ def handle_sanitize(args: argparse.Namespace):
             print(f"✅ Sanitized → {output_path}", file=sys.stderr)
 
         except SanitizeError as e:
+            if args.report_file:
+                _write_report_file(args.report_file, str(e))
             print(str(e), file=sys.stderr)
             sys.exit(1)
         except FileNotFoundError as e:

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -920,3 +920,57 @@ def test_repro_text_apply_paragraph_preservation_and_verification(tmp_path, caps
     expected_text_clean = re.sub(r"^>\s*\*\*File Path:\*\*.*?\n\n?", "", expected_text, count=1).strip()
 
     assert out_text.strip() == expected_text_clean
+
+
+def test_sanitize_report_file_written_on_blocked_run(tmp_path, capsys):
+    """
+    Verifies that `adeu sanitize --report-file <path>` writes the sanitize
+    report to the requested report file even when sanitization is BLOCKED
+    (e.g. due to unresolved tracked changes).
+    """
+    from io import BytesIO
+
+    import docx
+
+    from adeu.models import ModifyText
+    from adeu.redline.engine import RedlineEngine
+
+    # 1. Create a DOCX with tracked changes
+    doc = docx.Document()
+    doc.add_paragraph("This is the original contract text.")
+
+    buf = BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+
+    engine = RedlineEngine(buf)
+    engine.apply_edits([ModifyText(target_text="original", new_text="modified")])
+    res_buf = engine.save_to_stream()
+
+    input_docx = tmp_path / "doc_blocked.docx"
+    output_docx = tmp_path / "out_sanitized.docx"
+    report_file = tmp_path / "blocked_report.txt"
+
+    input_docx.write_bytes(res_buf.getvalue())
+
+    # 2. Run adeu sanitize requesting --report-file
+    args = [
+        "sanitize",
+        str(input_docx),
+        "-o",
+        str(output_docx),
+        "--report-file",
+        str(report_file),
+    ]
+
+    code, stdout, stderr = run_cli(args, capsys)
+
+    # 3. Verify it is blocked with exit code 1 and output DOCX is NOT created
+    assert code == 1
+    assert not output_docx.exists(), "Sanitized output DOCX should NOT be created on a blocked run"
+
+    # 4. Verify the report file WAS created on disk with the blocking reason
+    assert report_file.exists(), f"Expected report file {report_file} to exist on disk even on a blocked run"
+    report_text = report_file.read_text(encoding="utf-8")
+    assert "BLOCKED: Document contains" in report_text
+    assert "unresolved tracked changes" in report_text


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
When `adeu sanitize` was invoked in single-file mode with `--report-file <path>` on a document that was blocked (e.g. due to unresolved tracked changes or low-similarity baseline), `sanitize_docx` raised a `SanitizeError` carrying the rendered report text (`str(e)`). In `cli.py` (`handle_sanitize`), the `except SanitizeError as e:` block immediately printed `str(e)` to `stderr` and called `sys.exit(1)` without checking `args.report_file`. In contrast, batch sanitization appended `SanitizeError` results to `all_reports` and rendered the report file before exiting. This inconsistency caused single-file blocked runs to exit without writing `--report-file` to disk.

### The Fix
- **File:** `python/src/adeu/cli.py`
- **Function:** `handle_sanitize`
- **Details:** Added an `if args.report_file:` check inside `except SanitizeError as e:` in single-file mode to invoke `_write_report_file(args.report_file, str(e))` before exiting with status code 1. This ensures that the rendered block report is written to disk at the requested `--report-file` path, matching the behavior of batch sanitization and enabling automated pipelines to inspect block reasons programmatically.

### Sibling Occurrences
- **Batch mode (`handle_sanitize`):** Inspected `handle_sanitize` batch execution. Batch mode already appends `SanitizeError` instances to `all_reports` and writes `--report-file` during post-batch report generation before `sys.exit(1)`.
- **Other CLI subcommands:** Checked all other CLI subcommands (`extract`, `init`, `diff`, `apply`, `accept-all`, `markup`). `sanitize` is the only command accepting a `--report-file` option.
- **Node Engine / MCP Server:** Node `@adeu/core` and `@adeu/mcp-server` do not ship a standalone CLI binary; `sanitize_docx` in FastMCP surfaces `SanitizeError` as a `ToolError(str(e))`, which includes the block reason directly in the tool response.

### Verification
1. **Targeted Regression Test:**
   - Ran `uv run pytest tests/test_cli_bug_repro.py::test_sanitize_report_file_written_on_blocked_run`. PASSED.
2. **Full Python Test Suite:**
   - Ran `uv run pytest`. Result: 950 passed, 39 skipped in 6.75s.
3. **Linting & Formatting:**
   - Ran `uv run ruff check --fix .` and `uv run ruff format .`. Passed cleanly.
4. **Type Checking:**
   - Ran `uv run mypy src`. Result: Success (30 source files checked, no issues).
5. **Node Workspaces:**
   - Built and ran tests across all Node packages (`npm run build && npm test` in `node/`). Result: All 48 test files in `@adeu/core`, 17 test files in `@adeu/mcp-server`, and 2 test files in `n8n-nodes-adeu` passed (407 + 70 + 23 = 500 tests passed).

### Risk Assessment & Follow-Ups
- **Risk:** Low. The change only affects single-file `sanitize` execution when `--report-file` is explicitly specified on error/blocked paths. On success, behavior is unchanged.
- **Follow-ups:** None required for this iteration.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
**Severity:** S3 (Minor / UX / Pipeline Integration)  
**Description:** When `adeu sanitize` is executed in single-file mode with `--report-file <path>` on a document that is BLOCKED from sanitization (for example due to unresolved tracked changes or a low-similarity baseline), the CLI prints the blocking report text to `stderr` and exits with code 1, but fails to write the report content to the specified `--report-file` on disk. In contrast, batch mode sanitization writes `--report-file` regardless of whether inputs are blocked before exiting. This inconsistency prevents automated CI/CD pipelines and agentic orchestrators from reading `--report-file` to programmatically inspect block reasons.

### Minimal Reproduction
1. Create a DOCX document containing unresolved tracked changes (e.g. using `RedlineEngine` or `adeu apply`).
2. Run `adeu sanitize` specifying output path `-o out.docx` and `--report-file san_report.txt`:
   ```bash
   adeu sanitize doc_tc.docx -o out.docx --report-file san_report.txt
   ```
3. Check exit code and file existence:
   - Command exits with code 1 (expected due to unresolved changes).
   - `out.docx` is NOT created (expected safety behavior).
   - `san_report.txt` is NOT created on disk (BUG: expected `--report-file` to contain the rendered report text explaining why sanitization was blocked).

### Full Test Code
```python
def test_sanitize_report_file_written_on_blocked_run(tmp_path, capsys):
    """
    Verifies that `adeu sanitize --report-file <path>` writes the sanitize
    report to the requested report file even when sanitization is BLOCKED
    (e.g. due to unresolved tracked changes).
    """
    import docx
    from io import BytesIO
    from adeu.redline.engine import RedlineEngine
    from adeu.models import ModifyText

    # 1. Create a DOCX with tracked changes
    doc = docx.Document()
    doc.add_paragraph("This is the original contract text.")

    buf = BytesIO()
    doc.save(buf)
    buf.seek(0)

    engine = RedlineEngine(buf)
    engine.apply_edits([ModifyText(target_text="original", new_text="modified")])
    res_buf = engine.save_to_stream()

    input_docx = tmp_path / "doc_blocked.docx"
    output_docx = tmp_path / "out_sanitized.docx"
    report_file = tmp_path / "blocked_report.txt"

    input_docx.write_bytes(res_buf.getvalue())

    # 2. Run adeu sanitize requesting --report-file
    args = [
        "sanitize",
        str(input_docx),
        "-o",
        str(output_docx),
        "--report-file",
        str(report_file),
    ]

    code, stdout, stderr = run_cli(args, capsys)

    # 3. Verify it is blocked with exit code 1 and output DOCX is NOT created
    assert code == 1
    assert not output_docx.exists(), "Sanitized output DOCX should NOT be created on a blocked run"

    # 4. Verify the report file WAS created on disk with the blocking reason
    assert report_file.exists(), f"Expected report file {report_file} to exist on disk even on a blocked run"
    report_text = report_file.read_text(encoding="utf-8")
    assert "BLOCKED: Document contains" in report_text
    assert "unresolved tracked changes" in report_text
```

### Pytest Failure Output
```text
============================= test session starts ==============================
platform darwin -- Python 3.13.12, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0, anyio-4.14.2, hypothesis-6.156.6
created: 28/28 workers
28 workers [1 item]

F                                                                        [100%]
=================================== FAILURES ===================================
_______________ test_sanitize_report_file_written_on_blocked_run _______________
[gw0] darwin -- Python 3.13.12 /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/.venv/bin/python

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-75/popen-gw0/test_sanitize_report_file_writ0')
capsys = <_pytest.capture.CaptureFixture object at 0x10d4a1e80>

    def test_sanitize_report_file_written_on_blocked_run(tmp_path, capsys):
        """
        Verifies that `adeu sanitize --report-file <path>` writes the sanitize
        report to the requested report file even when sanitization is BLOCKED
        (e.g. due to unresolved tracked changes).
        """
        import docx
        from io import BytesIO
        from adeu.redline.engine import RedlineEngine
        from adeu.models import ModifyText
    
        # 1. Create a DOCX with tracked changes
        doc = docx.Document()
        doc.add_paragraph("This is the original contract text.")
    
        buf = BytesIO()
        doc.save(buf)
        buf.seek(0)
    
        engine = RedlineEngine(buf)
        engine.apply_edits([ModifyText(target_text="original", new_text="modified")])
        res_buf = engine.save_to_stream()
    
        input_docx = tmp_path / "doc_blocked.docx"
        output_docx = tmp_path / "out_sanitized.docx"
        report_file = tmp_path / "blocked_report.txt"
    
        input_docx.write_bytes(res_buf.getvalue())
    
        # 2. Run adeu sanitize requesting --report-file
        args = [
            "sanitize",
            str(input_docx),
            "-o",
            str(output_docx),
            "--report-file",
            str(report_file),
        ]
    
        code, stdout, stderr = run_cli(args, capsys)
    
        # 3. Verify it is blocked with exit code 1 and output DOCX is NOT created
        assert code == 1
        assert not output_docx.exists(), "Sanitized output DOCX should NOT be created on a blocked run"
    
        # 4. Verify the report file WAS created on disk with the blocking reason
>       assert report_file.exists(), f"Expected report file {report_file} to exist on disk even on a blocked run"
E       AssertionError: Expected report file /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-75/popen-gw0/test_sanitize_report_file_writ0/blocked_report.txt to exist on disk even on a blocked run
E       assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-75/popen-gw0/test_sanitize_report_file_writ0/blocked_report.txt').exists

tests/test_cli_bug_repro.py:971: AssertionError
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_sanitize_report_file_written_on_blocked_run
============================== 1 failed in 1.44s ===============================
```

### Expected Behavior
When `adeu sanitize` blocks execution (raising `SanitizeError` e.g. for unresolved tracked changes), if `--report-file <path>` was specified by the user, the CLI must write the rendered sanitize report (`str(e)`) to the `--report-file` path before exiting with code 1. The output `.docx` file must still NOT be created.


</details>
