### PR TITLE
fix: add -o/--output flag support to adeu diff subcommand

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -901,6 +901,16 @@ def _open_redline_engine_or_exit(path: Path, author: "str | None" = None) -> Red
 
 def handle_diff(args):
     _set_json_mode(args.json)
+    if _is_stdout_path(getattr(args, "output", None)):
+        args.output = None
+    if getattr(args, "output", None):
+        protected = []
+        if getattr(args, "original", None):
+            protected.append((args.original, "original DOCX"))
+        if getattr(args, "modified", None):
+            protected.append((args.modified, "modified file"))
+        _guard_text_output_path(args.output, protected, payload="diff output")
+
     from adeu.diff import DiffEdit, make_edits_self_contained
 
     edits: "Sequence[DiffEdit]"
@@ -958,25 +968,43 @@ def handle_diff(args):
         edits = make_edits_self_contained(text_edits, text_orig)
 
     if args.json:
-        output = [edit.model_dump(exclude={"_match_start_index"}) for edit in edits]
-        print(json.dumps(output, indent=2))
+        output_data = [edit.model_dump(exclude={"_match_start_index"}) for edit in edits]
+        json_output = json.dumps(output_data, indent=2)
+        if getattr(args, "output", None):
+            _write_output_or_exit(args.output, json_output)
+            print(f"Diff JSON saved to {args.output}", file=sys.stderr)
+        else:
+            print(json_output)
     elif not edits:
         # An explicit statement, on stdout: bare "Found 0 changes:" left the
         # reader to infer the documents are identical (QA 2026-07-23 F14).
-        print("No textual differences found.")
+        msg = "No textual differences found."
+        if getattr(args, "output", None):
+            _write_output_or_exit(args.output, msg + "\n")
+            print(f"Diff output saved to {args.output}", file=sys.stderr)
+        else:
+            print(msg)
     else:
-        print(f"Found {len(edits)} changes:", file=sys.stderr)
+        summary_lines = []
         for edit in edits:
             if isinstance(edit, InsertTableRow):
-                print(f"[+row] {' | '.join(edit.cells)} ({edit.position} '{edit.target_text[:40]}')")
+                summary_lines.append(f"[+row] {' | '.join(edit.cells)} ({edit.position} '{edit.target_text[:40]}')")
             elif isinstance(edit, DeleteTableRow):
-                print(f"[-row] {edit.target_text}")
+                summary_lines.append(f"[-row] {edit.target_text}")
             elif not edit.new_text:
-                print(f"[-] {edit.target_text}")
+                summary_lines.append(f"[-] {edit.target_text}")
             elif not edit.target_text:
-                print(f"[+] {edit.new_text}")
+                summary_lines.append(f"[+] {edit.new_text}")
             else:
-                print(f"[~] '{edit.target_text}' -> '{edit.new_text}'")
+                summary_lines.append(f"[~] '{edit.target_text}' -> '{edit.new_text}'")
+
+        if getattr(args, "output", None):
+            _write_output_or_exit(args.output, "\n".join(summary_lines) + "\n")
+            print(f"Found {len(edits)} changes (saved to {args.output}):", file=sys.stderr)
+        else:
+            print(f"Found {len(edits)} changes:", file=sys.stderr)
+            for line in summary_lines:
+                print(line)
 
 
 def handle_apply(args):
@@ -1798,6 +1826,7 @@ def _main_impl():
     p_diff = subparsers.add_parser("diff", help="Compare two files (DOCX vs DOCX/Text)")
     p_diff.add_argument("original", type=Path, help="Original DOCX")
     p_diff.add_argument("modified", type=Path, help="Modified DOCX or Text file")
+    p_diff.add_argument("-o", "--output", type=Path, help="Output file path (default: stdout)")
     p_diff.add_argument("--json", action="store_true", help="Output raw JSON edits")
     p_diff.add_argument(
         "--compare-clean",

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -974,3 +974,118 @@ def test_sanitize_report_file_written_on_blocked_run(tmp_path, capsys):
     report_text = report_file.read_text(encoding="utf-8")
     assert "BLOCKED: Document contains" in report_text
     assert "unresolved tracked changes" in report_text
+
+
+def test_diff_output_flag_support(tmp_path, capsys):
+    """
+    Verifies that `adeu diff` accepts `-o` / `--output` flags to write diff
+    results directly to a file, matching the interface contract of sibling
+    subcommands (extract, apply, accept-all, markup, sanitize).
+    """
+    import json
+
+    import docx
+
+    # 1. Create original and modified documents
+    orig_path = tmp_path / "orig.docx"
+    mod_path = tmp_path / "mod.docx"
+
+    doc1 = docx.Document()
+    doc1.add_paragraph("Original Section Text")
+    doc1.save(str(orig_path))
+
+    doc2 = docx.Document()
+    doc2.add_paragraph("Modified Section Text")
+    doc2.save(str(mod_path))
+
+    out_json_path = tmp_path / "diff_output.json"
+
+    # 2. Invoke adeu diff with --json -o <path>
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(mod_path), "--json", "-o", str(out_json_path)],
+        capsys,
+    )
+
+    # 3. Assert success and file creation
+    assert code == 0, f"adeu diff -o failed with exit code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
+    assert out_json_path.exists(), f"Expected diff output file {out_json_path} to exist"
+
+    # 4. Verify output file contains valid JSON diff payload
+    content = out_json_path.read_text(encoding="utf-8")
+    data = json.loads(content)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert data[0].get("type") == "modify"
+
+    # 5. Also test --output variant
+    out_json_path2 = tmp_path / "diff_output2.json"
+    code2, stdout2, stderr2 = run_cli(
+        ["diff", str(orig_path), str(mod_path), "--json", "--output", str(out_json_path2)],
+        capsys,
+    )
+    assert code2 == 0, f"adeu diff --output failed with exit code {code2}.\nSTDERR:\n{stderr2}"
+    assert out_json_path2.exists(), f"Expected diff output file {out_json_path2} to exist"
+
+
+def test_diff_output_flag_text_and_guards(tmp_path, capsys):
+    """
+    Verifies text-mode output files, `-o -` stdout handling, and path guardrails
+    for `adeu diff -o`.
+    """
+    import docx
+
+    orig_path = tmp_path / "orig.docx"
+    mod_path = tmp_path / "mod.docx"
+
+    doc1 = docx.Document()
+    doc1.add_paragraph("Original Section Text")
+    doc1.save(str(orig_path))
+
+    doc2 = docx.Document()
+    doc2.add_paragraph("Modified Section Text")
+    doc2.save(str(mod_path))
+
+    # 1. Text mode with differences -> written to -o
+    out_txt_path = tmp_path / "diff_output.txt"
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(mod_path), "-o", str(out_txt_path)],
+        capsys,
+    )
+    assert code == 0, f"adeu diff -o text failed: {stderr}"
+    assert out_txt_path.exists()
+    content = out_txt_path.read_text(encoding="utf-8")
+    assert "[~]" in content or "Original Section Text" in content
+
+    # 2. Text mode with no differences -> written to -o
+    out_no_diff = tmp_path / "no_diff.txt"
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(orig_path), "-o", str(out_no_diff)],
+        capsys,
+    )
+    assert code == 0, f"adeu diff -o no diff failed: {stderr}"
+    assert out_no_diff.exists()
+    assert "No textual differences found." in out_no_diff.read_text(encoding="utf-8")
+
+    # 3. `-o -` streams to stdout
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(mod_path), "--json", "-o", "-"],
+        capsys,
+    )
+    assert code == 0
+    assert "Original" in stdout
+
+    # 4. Guard against overwriting input file
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(mod_path), "-o", str(orig_path)],
+        capsys,
+    )
+    assert code == 1
+    assert "same file" in stderr or "invalid_input" in stderr
+
+    # 5. Guard against .docx output path
+    code, stdout, stderr = run_cli(
+        ["diff", str(orig_path), str(mod_path), "-o", str(tmp_path / "out.docx")],
+        capsys,
+    )
+    assert code == 1
+    assert "refusing" in stderr.lower() or "invalid_input" in stderr


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
The `adeu diff` subcommand parser in `src/adeu/cli.py` did not define the `-o` / `--output` CLI argument options (`p_diff.add_argument("-o", "--output", ...)`). Consequently, `argparse` rejected invocations including `-o` or `--output` with an unrecognized argument error (exit code 2), breaking CLI invocation parity with sibling subcommands (`extract`, `apply`, `accept-all`, `markup`, and `sanitize`).

### The Fix
1. **Parser Registration (`src/adeu/cli.py`)**: Added `p_diff.add_argument("-o", "--output", type=Path, help="Output file path (default: stdout)")` to the `diff` subcommand argument parser definition.
2. **Output Handling (`src/adeu/cli.py`)**: Updated `handle_diff` to:
   - Normalize stdout redirection when passed `-o -` via `_is_stdout_path`.
   - Guard against output paths that alias the input files or carry invalid `.docx` extensions via `_guard_text_output_path`.
   - Write the diff payload (JSON or formatted text summary) safely to the target path using atomic file staging via `_write_output_or_exit`.
3. **Regression Tests (`tests/test_cli_bug_repro.py`)**: Verified `test_diff_output_flag_support` and added `test_diff_output_flag_text_and_guards` covering text mode outputs, stdout streaming (`-o -`), input-alias protection, and `.docx` extension refusal.

### Sibling Occurrences
Checked all subcommands in `src/adeu/cli.py` (`extract`, `init`, `diff`, `apply`, `accept-all`, `markup`, `sanitize`, `help`). All file-producing subcommands now support `-o`/`--output` consistently. The Node/TS package has no CLI interface and handles diffs purely via MCP/library APIs.

### Verification
- `uv run pytest tests/test_cli_bug_repro.py`: All 22 tests passed (including `test_diff_output_flag_support` and `test_diff_output_flag_text_and_guards`).
- `uv run pytest`: Full Python test suite passed cleanly (967 passed, 39 skipped).
- `uv run ruff check --fix .` & `uv run ruff format .`: Zero lint issues remaining, formatted.
- `uv run mypy src`: Clean (no type errors in 27 source files).
- `cd node && npm test`: Vitest suite passed cleanly (137 tests across 10 files).

### Risk Assessment & Follow-ups
- **Risk**: Minimal, as adding `-o`/`--output` restores CLI parity without altering core diff generation algorithms or default stdout behavior when `-o` is omitted.
- **Follow-ups**: None required for this iteration.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
**Severity:** S3 (Minor UX Friction & CLI Interface Asymmetry)  
**Bug:** The `adeu diff` subcommand lacks support for the `-o` / `--output` CLI flag option, unlike all sibling subcommands (`extract`, `apply`, `accept-all`, `markup`, and `sanitize`) which accept `-o`/`--output` to direct output to a target file path. Attempting to run `adeu diff orig.docx mod.docx --json -o diff.json` fails during argument parsing with exit code 2 and `adeu diff: error: unrecognized arguments: -o diff.json`.

### Minimal Reproduction
From scratch experiments:
```bash
# 1. Create two simple DOCX files
python -c "import docx; d = docx.Document(); d.add_paragraph('Original Text'); d.save('orig.docx')"
python -c "import docx; d = docx.Document(); d.add_paragraph('Modified Text'); d.save('mod.docx')"

# 2. Attempt adeu diff using -o flag
adeu diff orig.docx mod.docx --json -o diff.json
```
**Output:**
```
usage: adeu diff [-h] [--json] [--compare-clean | --no-compare-clean]
                 original modified
adeu diff: error: unrecognized arguments: -o diff.json
```

### Full Test Code
```python
def test_diff_output_flag_support(tmp_path, capsys):
    """
    Verifies that `adeu diff` accepts `-o` / `--output` flags to write diff
    results directly to a file, matching the interface contract of sibling
    subcommands (extract, apply, accept-all, markup, sanitize).
    """
    import json
    import docx

    # 1. Create original and modified documents
    orig_path = tmp_path / "orig.docx"
    mod_path = tmp_path / "mod.docx"

    doc1 = docx.Document()
    doc1.add_paragraph("Original Section Text")
    doc1.save(str(orig_path))

    doc2 = docx.Document()
    doc2.add_paragraph("Modified Section Text")
    doc2.save(str(mod_path))

    out_json_path = tmp_path / "diff_output.json"

    # 2. Invoke adeu diff with --json -o <path>
    code, stdout, stderr = run_cli(
        ["diff", str(orig_path), str(mod_path), "--json", "-o", str(out_json_path)],
        capsys,
    )

    # 3. Assert success and file creation
    assert code == 0, f"adeu diff -o failed with exit code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
    assert out_json_path.exists(), f"Expected diff output file {out_json_path} to exist"

    # 4. Verify output file contains valid JSON diff payload
    content = out_json_path.read_text(encoding="utf-8")
    data = json.loads(content)
    assert isinstance(data, list)
    assert len(data) > 0
    assert data[0].get("type") == "modify"

    # 5. Also test --output variant
    out_json_path2 = tmp_path / "diff_output2.json"
    code2, stdout2, stderr2 = run_cli(
        ["diff", str(orig_path), str(mod_path), "--json", "--output", str(out_json_path2)],
        capsys,
    )
    assert code2 == 0, f"adeu diff --output failed with exit code {code2}.\nSTDERR:\n{stderr2}"
    assert out_json_path2.exists(), f"Expected diff output file {out_json_path2} to exist"
```

### Pytest Failure Output
```
________________________ test_diff_output_flag_support _________________________
[gw27] darwin -- Python 3.13.12 /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/.venv/bin/python

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-89/popen-gw27/test_diff_output_flag_support0')
capsys = <_pytest.capture.CaptureFixture object at 0x10d6e5e80>

    def test_diff_output_flag_support(tmp_path, capsys):
        """
        Verifies that `adeu diff` accepts `-o` / `--output` flags to write diff
        results directly to a file, matching the interface contract of sibling
        subcommands (extract, apply, accept-all, markup, sanitize).
        """
        import json
        import docx
    
        # 1. Create original and modified documents
        orig_path = tmp_path / "orig.docx"
        mod_path = tmp_path / "mod.docx"
    
        doc1 = docx.Document()
        doc1.add_paragraph("Original Section Text")
        doc1.save(str(orig_path))
    
        doc2 = docx.Document()
        doc2.add_paragraph("Modified Section Text")
        doc2.save(str(mod_path))
    
        out_json_path = tmp_path / "diff_output.json"
    
        # 2. Invoke adeu diff with --json -o <path>
        code, stdout, stderr = run_cli(
            ["diff", str(orig_path), str(mod_path), "--json", "-o", str(out_json_path)],
            capsys,
        )
    
        # 3. Assert success and file creation
>       assert code == 0, f"adeu diff -o failed with exit code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
E       AssertionError: adeu diff -o failed with exit code 2.
E         STDERR:
E         usage: adeu diff [-h] [--json] [--compare-clean | --no-compare-clean]
E                          original modified
E         adeu diff: error: unrecognized arguments: -o /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-89/popen-gw27/test_diff_output_flag_support0/diff_output.json
E         
E         STDOUT:
E         
E       assert 2 == 0

tests/test_cli_bug_repro.py:1009: AssertionError
```

### Expected Behavior Once Fixed
When `adeu diff orig.docx mod.docx [-o | --output] <file_path>` is run (with or without `--json`), the command should exit 0 and write the generated diff content (JSON or text) directly to `<file_path>` instead of rejecting `-o`/`--output` as an unrecognized argument.


</details>
