### PR TITLE
fix: Automated agentic CLI (adeu) bug fix

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1007,6 +1007,14 @@ def handle_diff(args):
                 print(line)
 
 
+def _normalize_virtual_projection_text(text: str) -> str:
+    """
+    Normalizes virtual Markdown projection chrome (such as heading prefixes)
+    so post-apply verification evaluates pure text equivalence.
+    """
+    return re.sub(r"^#+\s*", "", text, flags=re.MULTILINE)
+
+
 def handle_apply(args):
     _set_json_mode(args.json)
     # Author flows into w:author attributes; XML-illegal control characters
@@ -1172,18 +1180,22 @@ def handle_apply(args):
         final_clean = _extract_text_from_doc(engine.doc, clean_view=True, include_appendix=False)
         expected = verify_against.strip()
         actual = final_clean.strip()
-        if actual != expected:
+
+        actual_norm = _normalize_virtual_projection_text(actual)
+        expected_norm = _normalize_virtual_projection_text(expected)
+
+        if actual_norm != expected_norm:
             div = next(
-                (k for k, (a, b) in enumerate(zip(actual, expected, strict=False)) if a != b),
-                min(len(actual), len(expected)),
+                (k for k, (a, b) in enumerate(zip(actual_norm, expected_norm, strict=False)) if a != b),
+                min(len(actual_norm), len(expected_norm)),
             )
             assert output_path is not None
             unverified_path = output_path.with_name(f"{output_path.stem}.unverified.docx")
             verification_error = (
                 "Post-apply verification failed: the applied document's clean text does not match "
                 f"the supplied text (first divergence at character {div}: "
-                f"applied reads {actual[div : div + 40]!r}, supplied text reads "
-                f"{expected[div : div + 40]!r}). The document structure could not fully realize "
+                f"applied reads {actual_norm[div : div + 40]!r}, supplied text reads "
+                f"{expected_norm[div : div + 40]!r}). The document structure could not fully realize "
                 "the requested text (e.g. headings or table cells cannot be deleted via text "
                 f"replacement). Nothing was written to '{output_path}'; a diagnostic copy was "
                 f"kept at '{unverified_path}' — it is NOT the requested document."

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -1089,3 +1089,41 @@ def test_diff_output_flag_text_and_guards(tmp_path, capsys):
     )
     assert code == 1
     assert "refusing" in stderr.lower() or "invalid_input" in stderr
+
+
+def test_post_apply_verification_plain_text_without_heading_prefix(tmp_path, capsys):
+    """
+    Verifies that applying a plain text file without Markdown heading prefixes (# )
+    to a document containing headings does not fail post-apply verification.
+
+    When adeu apply computes a diff between a docx (extracted as '# Heading') and
+    a plain text file ('Heading'), it produces a virtual edit targeting '# '.
+    Post-apply verification should pass and successfully create the output document.
+    """
+    import docx
+
+    # 1. Create a document with a heading and paragraph
+    doc_path = tmp_path / "doc_with_heading.docx"
+    doc = docx.Document()
+    doc.add_heading("Executive Summary", level=1)
+    doc.add_paragraph("Initial project timeline is 30 days.")
+    doc.save(str(doc_path))
+
+    # 2. Create a modified plain text file without '# ' prefix
+    txt_path = tmp_path / "modified_plain.txt"
+    txt_path.write_text(
+        "Executive Summary\n\nInitial project timeline is 60 days.\n",
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "out.docx"
+
+    # 3. Run adeu apply
+    code, stdout, stderr = run_cli(
+        ["apply", str(doc_path), str(txt_path), "-o", str(out_path)],
+        capsys,
+    )
+
+    # 4. Assert that verification passes, return code is 0, and output file is written
+    assert code == 0, f"adeu apply failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
+    assert out_path.exists(), f"Expected output file {out_path} to be created"


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[18:30:59] I have resolved the post-apply verification issue when applying plain text files without Markdown heading prefixes (`# `).
[18:30:59] 
[18:30:59] ### Root Cause & Investigation
[18:31:00] When `adeu apply` is executed with a modified plain text file (`modified.txt`) against a Word document containing headings, `generate_edits_via_paragraph_alignment` diffs `text_orig` (extracted clean view, e.g. `# Executive Summary`) against `text_mod` (`Executive Summary`), yielding a virtual edit targeting `# `.
[18:31:00] During execution, `RedlineEngine` recognizes `# ` as virtual projection text (heading syntax) and treats the change as a virtual no-op on the underlying OpenXML DOM, leaving paragraph styles intact in `engine.doc`.
[18:31:00] However, the post-apply verification step re-extracted the clean view from `engine.doc` (`# Executive Summary`) and compared it verbatim against `verify_against` (`Executive Summary`). Because the strings diverged at character 0, post-apply verification failed, suppressing the final document output and raising a false verification failure.
[18:31:00] 
[18:31:00] ### Fix Details
[18:31:01] 1. **Virtual Projection Normalization (`src/adeu/cli.py`)**: Added `_normalize_virtual_projection_text` to strip virtual Markdown projection chrome (specifically line-leading Markdown heading prefixes `^#+\s*`) from both the re-extracted clean view (`actual`) and the supplied text (`expected`) before performing the equivalence check.
[18:31:01] 2. **Preserved Failure Guards**: Actual text discrepancies (e.g. unapplied text modifications or structural deletion failures) continue to fail verification with accurate line/character character offset reporting.
[18:31:01] 3. **Regression Test (`tests/test_cli_bug_repro.py`)**: Added `test_post_apply_verification_plain_text_without_heading_prefix` to verify that plain-text apply operations against documents with headings pass post-apply verification, exit with status code 0, and write the expected `.docx` file.
[18:31:01] 
[18:31:01] ### Verification
[18:31:01] - **Regression Test**: `uv run pytest tests/test_cli_bug_repro.py::test_post_apply_verification_plain_text_without_heading_prefix` (PASSED)
[18:31:01] - **Full Test Suite**: `uv run pytest` (968 passed, 39 skipped)
[18:31:01] - **Lint & Types**: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src/adeu` (All checks passed)


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
**Severity**: S1 (High User Harm / Broken Core Workflow Feature)
When `adeu apply` is executed with a modified plain text file (`.txt`) against a Word document containing headings, `adeu diff` generates edits targeting virtual Markdown heading markers (e.g., `# `). During application, the redline engine treats changes to Markdown heading syntax as virtual projection chrome (no-op on underlying OpenXML paragraph styles). However, the post-apply verification check re-extracts the document's clean view (which still includes `# ` heading prefixes) and compares it verbatim against the supplied plain text file (which lacks `# ` prefixes). Because the strings diverge at character 0, post-apply verification fails and aborts without writing the requested output `.docx` file, leaving only a `.unverified.docx` diagnostic copy.

### Minimal Reproduction
1. Create a DOCX document with a level 1 heading:
   ```python
   import docx
   doc = docx.Document()
   doc.add_heading("Executive Summary", level=1)
   doc.add_paragraph("Initial project timeline is 30 days.")
   doc.save("doc_with_heading.docx")
   ```
2. Create a modified plain text file omitting the `# ` Markdown heading prefix:
   ```text
   Executive Summary

   Initial project timeline is 60 days.
   ```
3. Run `adeu apply`:
   ```bash
   adeu apply doc_with_heading.docx modified_plain.txt -o out.docx
   ```
   **Result**: Fails with `Post-apply verification failed` and exits 1 without creating `out.docx`.

### Full Test Code
```python
def test_post_apply_verification_plain_text_without_heading_prefix(tmp_path, capsys):
    """
    Verifies that applying a plain text file without Markdown heading prefixes (# )
    to a document containing headings does not fail post-apply verification.

    When adeu apply computes a diff between a docx (extracted as '# Heading') and
    a plain text file ('Heading'), it produces a virtual edit targeting '# '.
    Post-apply verification should pass and successfully create the output document.
    """
    import docx

    # 1. Create a document with a heading and paragraph
    doc_path = tmp_path / "doc_with_heading.docx"
    doc = docx.Document()
    doc.add_heading("Executive Summary", level=1)
    doc.add_paragraph("Initial project timeline is 30 days.")
    doc.save(str(doc_path))

    # 2. Create a modified plain text file without '# ' prefix
    txt_path = tmp_path / "modified_plain.txt"
    txt_path.write_text(
        "Executive Summary\n\nInitial project timeline is 60 days.\n",
        encoding="utf-8",
    )

    out_path = tmp_path / "out.docx"

    # 3. Run adeu apply
    code, stdout, stderr = run_cli(
        ["apply", str(doc_path), str(txt_path), "-o", str(out_path)],
        capsys,
    )

    # 4. Assert that verification passes, return code is 0, and output file is written
    assert code == 0, f"adeu apply failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
    assert out_path.exists(), f"Expected output file {out_path} to be created"
```

### Pytest Failure Output
```
________________ test_post_apply_verification_plain_text_without_heading_prefix ________________
[gw2] darwin -- Python 3.13.12 /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/.venv/bin/python

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0')
capsys = <_pytest.capture.CaptureFixture object at 0x10ac75e80>

    def test_post_apply_verification_plain_text_without_heading_prefix(tmp_path, capsys):
        """
        Verifies that applying a plain text file without Markdown heading prefixes (# )
        to a document containing headings does not fail post-apply verification.
    
        When adeu apply computes a diff between a docx (extracted as '# Heading') and
        a plain text file ('Heading'), it produces a virtual edit targeting '# '.
        Post-apply verification should pass and successfully create the output document.
        """
        import docx
    
        # 1. Create a document with a heading and paragraph
        doc_path = tmp_path / "doc_with_heading.docx"
        doc = docx.Document()
        doc.add_heading("Executive Summary", level=1)
        doc.add_paragraph("Initial project timeline is 30 days.")
        doc.save(str(doc_path))
    
        # 2. Create a modified plain text file without '# ' prefix
        txt_path = tmp_path / "modified_plain.txt"
        txt_path.write_text(
            "Executive Summary\n\nInitial project timeline is 60 days.\n",
            encoding="utf-8",
        )
    
        out_path = tmp_path / "out.docx"
    
        # 3. Run adeu apply
        code, stdout, stderr = run_cli(
            ["apply", str(doc_path), str(txt_path), "-o", str(out_path)],
            capsys,
        )
    
        # 4. Assert that verification passes, return code is 0, and output file is written
>       assert code == 0, f"adeu apply failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
E       AssertionError: adeu apply failed with code 1.
E         STDERR:
E         Calculating diff from text file /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0/modified_plain.txt...
E         Applying 2 changes to doc_with_heading.docx...
E         ❌ Verification failed — no output was written to: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0/out.docx
E            A diagnostic copy (NOT the requested document) was kept at: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0/out.unverified.docx
E         Actions: 0 applied, 0 skipped.
E         Edits: 2 applied, 0 skipped.
E         
E         Detailed Edit Reports:
E         Edit 1 ✅ [applied]:
E           Target: '# '
E           New text: ''
E           Preview (CriticMarkup): {--# --}Executive Summary
E         
E         Initial pro
E           Clean text preview: Executive Summary
E         
E         Initial pro
E         Edit 2 ✅ [applied]:
E           Target: '30'
E           New text: '60'
E           Preview (CriticMarkup): 
E         
E         Initial project timeline is {--30--}{++60++} days.
E           Clean text preview: 
E         
E         Initial project timeline is 60 days.
E         
E         ❌ Post-apply verification failed: the applied document's clean text does not match the supplied text (first divergence at character 0: applied reads '# Executive Summary\n\nInitial project tim', supplied text reads 'Executive Summary\n\nInitial project timel'). The document structure could not fully realize the requested text (e.g. headings or table cells cannot be deleted via text replacement). Nothing was written to '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0/out.docx'; a diagnostic copy was kept at '/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-104/popen-gw2/test_post_apply_verification_p0/out.unverified.docx' — it is NOT the requested document.
E         
E         STDOUT:
E         
E       assert 1 == 0

tests/test_cli_bug_repro.py:1128: AssertionError
```

### Expected Behavior Once Fixed
When `adeu apply` compares the post-apply document's clean view against the supplied input text, virtual Markdown projection syntax (such as heading prefixes `# `) should be normalized before comparing for text equivalence, or post-apply verification should account for virtual heading projection markers. As a result, `adeu apply` should successfully write the output document at the requested path (`-o`) with return code 0.


</details>
