### PR TITLE
fix: Automated agentic CLI (adeu) bug fix

### DIFF
--- a/docs/cli-agent-spec.md
+++ b/docs/cli-agent-spec.md
@@ -55,6 +55,23 @@ single JSON document and the human-readable progress logs are suppressed.
   the file; the JSON envelope goes to stdout).
 * **`adeu diff --json`** — prints the raw edit array (pre-existing behavior).
 * **`adeu accept-all --json`** — prints `{"status": "ok", "output_path": ...}`.
+* **`adeu sanitize --json`** — prints the `sanitize_docx` MCP tool's payload
+  field-for-field (`status`, `output_path`, `tracked_changes_found`,
+  `tracked_changes_accepted`, `comments_removed`, `comments_kept`,
+  `metadata_stripped`, `warnings`, `report_text`) plus the CLI-only `input`, so
+  one parser serves both surfaces. **`status` here is the document verdict** —
+  `clean`, `clean_with_warnings`, or `blocked` — *not* an invocation outcome:
+  success is the exit code. A refusal (unresolved tracked changes) is a normal
+  payload, `{"status": "blocked", "error": "blocked", "message": <one-line
+  reason>, "report_text": <full report>}`, and exits 1.
+  Batch mode (`--outdir`) wraps them in a CLI-shaped envelope — `status`
+  (`ok`/`failed`, batch-level), `outdir`, `total`, `succeeded`, `blocked`,
+  `results` — where `results` holds one entry per input **in input order**, so
+  `len(results) == total` always holds and every failure (`blocked`,
+  `invalid_docx`, `file_not_found`) is identified by its `input`. A failed
+  batch adds `{"error": "batch_failed", "message": ...}` and writes no outputs.
+  `--json` cannot be combined with `--report-file -` (both target stdout); the
+  report is in `report_text` instead.
 
 ## 4. Strict I/O discipline
 
@@ -83,5 +100,5 @@ adeu accept-all contract_redlined.docx --json         # finalize (optional)
 ```
 
 Regression coverage lives in `python/tests/test_cli_features.py`
-(`test_cli_apply_json*`, `test_cli_accept_all*`,
+(`test_cli_apply_json*`, `test_cli_accept_all*`, `test_cli_sanitize_json*`,
 `test_cli_debug_logs_go_to_stderr_only`).

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1453,8 +1453,23 @@ def handle_markup(args):
     print(stats_line, file=sys.stderr)
 
 
+def _sanitize_block_reason(report_text: str) -> str:
+    """
+    One-line diagnostic for a SanitizeError, for the `message` field of a
+    --json payload. A policy block renders as a full report whose `BLOCKED:`
+    line carries the actionable reason; operational SanitizeErrors (an
+    unwritable output, an incompatible --baseline) are already single-line.
+    The full text always travels alongside in `report_text`.
+    """
+    for line in report_text.splitlines():
+        if line.startswith("BLOCKED: "):
+            return line[len("BLOCKED: ") :]
+    return report_text.strip()
+
+
 def handle_sanitize(args: argparse.Namespace):
-    _set_json_mode(getattr(args, "json", False))
+    json_mode = bool(getattr(args, "json", False))
+    _set_json_mode(json_mode)
     from adeu.redline.engine import describe_illegal_control_chars
 
     author_ctrl = describe_illegal_control_chars(args.author or "")
@@ -1482,6 +1497,17 @@ def handle_sanitize(args: argparse.Namespace):
         print(
             "❌ -o/--output and --outdir are mutually exclusive: -o names a single output file, "
             "--outdir selects batch mode. Pass exactly one of them.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if json_mode and _is_stdout_path(args.report_file):
+        # Both write to stdout, and the report text ahead of the JSON object
+        # breaks the one-JSON-document-per-invocation contract (cli-agent-spec
+        # §4). The payload already carries the report in `report_text`.
+        print(
+            "❌ --json and --report-file - are mutually exclusive: both write to stdout, so the "
+            "report text would corrupt the JSON document. Drop --report-file - and read the "
+            "report from the payload's report_text field.",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -1530,20 +1556,28 @@ def handle_sanitize(args: argparse.Namespace):
                 if args.report_file:
                     _write_report_file(args.report_file, result.report_text)
 
-            if getattr(args, "json", False):
-                json_result = {
-                    "status": "ok",
-                    "sanitize_status": result.status,
-                    "input": str(input_path),
-                    "output_path": str(output_path),
-                    "tracked_changes_found": result.tracked_changes_found,
-                    "tracked_changes_accepted": result.tracked_changes_accepted,
-                    "comments_removed": result.comments_removed,
-                    "comments_kept": result.comments_kept,
-                    "metadata_stripped": result.metadata_stripped,
-                    "warnings": result.warnings,
-                }
-                print(json.dumps(json_result))
+            if json_mode:
+                # Field-for-field the `sanitize` MCP tool's payload (plus the
+                # CLI-only `input`), so one parser serves both surfaces — the
+                # CLI is the sandboxed stand-in for the tool. `status` is the
+                # DOCUMENT verdict ("clean"/"clean_with_warnings"/"blocked"),
+                # never an invocation outcome: success is the exit code.
+                print(
+                    json.dumps(
+                        {
+                            "status": result.status,
+                            "input": str(input_path),
+                            "output_path": str(output_path),
+                            "tracked_changes_found": result.tracked_changes_found,
+                            "tracked_changes_accepted": result.tracked_changes_accepted,
+                            "comments_removed": result.comments_removed,
+                            "comments_kept": result.comments_kept,
+                            "metadata_stripped": result.metadata_stripped,
+                            "warnings": result.warnings,
+                            "report_text": result.report_text,
+                        }
+                    )
+                )
             else:
                 print(f"✅ Sanitized → {output_path}", file=sys.stderr)
 
@@ -1554,8 +1588,22 @@ def handle_sanitize(args: argparse.Namespace):
             print(str(e), file=sys.stderr)
             if args.report_file:
                 _write_report_file(args.report_file, str(e))
-            if getattr(args, "json", False):
-                print(json.dumps({"error": "invalid_input", "message": str(e)}))
+            if json_mode:
+                # A refusal is a well-understood outcome, not a malformed
+                # input: it travels as `status: "blocked"` + `report_text`,
+                # the same shape the MCP tool returns, alongside the CLI's
+                # {error, message} pair.
+                print(
+                    json.dumps(
+                        {
+                            "status": "blocked",
+                            "input": str(input_path),
+                            "error": "blocked",
+                            "message": _sanitize_block_reason(str(e)),
+                            "report_text": str(e),
+                        }
+                    )
+                )
             sys.exit(1)
         except FileNotFoundError as e:
             _cli_error("file_not_found", str(e))
@@ -1610,6 +1658,10 @@ def handle_sanitize(args: argparse.Namespace):
         # artifacts too: the finally-sweep below guarantees none survive a
         # failed batch, whatever the exit path (QA 2026-07-19 v8 F-02).
         all_reports: list[SanitizeResult | SanitizeError] = []
+        # One --json entry per input, in input order, whatever the outcome:
+        # `len(results) == total` always holds, so automation identifies every
+        # failure (and WHICH document failed) from the payload alone.
+        json_results: List[Dict[str, Any]] = []
         staged: List[tuple[Path, Path]] = []
         blocked = 0
         succeeded = 0
@@ -1619,6 +1671,14 @@ def handle_sanitize(args: argparse.Namespace):
                 if not input_path.exists():
                     print(f"❌ File not found: {input_path}", file=sys.stderr)
                     blocked += 1
+                    json_results.append(
+                        {
+                            "status": "error",
+                            "input": str(input_path),
+                            "error": "file_not_found",
+                            "message": f"File not found: {input_path}",
+                        }
+                    )
                     continue
 
                 output_path = outdir / input_path.name
@@ -1645,18 +1705,42 @@ def handle_sanitize(args: argparse.Namespace):
                     result.output_path = str(output_path)
                     staged.append((staging_path, output_path))
                     all_reports.append(result)
+                    json_results.append(
+                        {
+                            "status": result.status,
+                            "input": str(input_path),
+                            "output_path": result.output_path,
+                            "tracked_changes_found": result.tracked_changes_found,
+                            "tracked_changes_accepted": result.tracked_changes_accepted,
+                            "comments_removed": result.comments_removed,
+                            "comments_kept": result.comments_kept,
+                            "metadata_stripped": result.metadata_stripped,
+                            "warnings": result.warnings,
+                            "report_text": result.report_text,
+                        }
+                    )
                     succeeded += 1
                     status = "clean"
                     if result.warnings:
                         status = f"clean ({len(result.warnings)} warning{'s' if len(result.warnings) > 1 else ''})"
-                    if not getattr(args, "json", False):
+                    # Per-file progress is decorative under --json; per-file
+                    # FAILURES below are not, and stay on stderr either way.
+                    if not json_mode:
                         print(f"  ✓ {input_path.name:<30} — {status}", file=sys.stderr)
 
                 except SanitizeError as e:
                     blocked += 1
-                    if not getattr(args, "json", False):
-                        print(f"  ✗ {input_path.name:<30} — BLOCKED", file=sys.stderr)
+                    print(f"  ✗ {input_path.name:<30} — BLOCKED", file=sys.stderr)
                     all_reports.append(e)
+                    json_results.append(
+                        {
+                            "status": "blocked",
+                            "input": str(input_path),
+                            "error": "blocked",
+                            "message": _sanitize_block_reason(str(e)),
+                            "report_text": str(e),
+                        }
+                    )
 
                 except Exception as e:
                     # An invalid input blocks the batch like any other failure;
@@ -1664,18 +1748,23 @@ def handle_sanitize(args: argparse.Namespace):
                     # the staged-file cleanup and leaves document content
                     # behind as .staging.tmp files (QA 2026-07-19 v8 F-02).
                     blocked += 1
-                    if not getattr(args, "json", False):
-                        if (
-                            "bad zip signature" in str(e)
-                            or "not a zip file" in str(e).lower()
-                            or "not a valid DOCX file" in str(e)
-                        ):
-                            print(
-                                f"  ✗ {input_path.name:<30} — ERROR: not a valid DOCX file (bad zip signature)",
-                                file=sys.stderr,
-                            )
-                        else:
-                            print(f"  ✗ {input_path.name:<30} — ERROR: {e}", file=sys.stderr)
+                    if (
+                        "bad zip signature" in str(e)
+                        or "not a zip file" in str(e).lower()
+                        or "not a valid DOCX file" in str(e)
+                    ):
+                        code, message = "invalid_docx", "not a valid DOCX file (bad zip signature)"
+                    else:
+                        code, message = "invalid_input", str(e)
+                    print(f"  ✗ {input_path.name:<30} — ERROR: {message}", file=sys.stderr)
+                    json_results.append(
+                        {
+                            "status": "error",
+                            "input": str(input_path),
+                            "error": code,
+                            "message": message,
+                        }
+                    )
 
             if blocked == 0:
                 for staging_path, output_path in staged:
@@ -1700,36 +1789,18 @@ def handle_sanitize(args: argparse.Namespace):
         if blocked > 0:
             summary += "\nBatch failed — no outputs were written (the batch is all-or-nothing)."
 
-        if getattr(args, "json", False):
-            batch_results: list[dict[str, Any]] = []
-            for r in all_reports:
-                if isinstance(r, SanitizeError):
-                    batch_results.append(
-                        {
-                            "status": "blocked",
-                            "error": str(r),
-                        }
-                    )
-                else:
-                    batch_results.append(
-                        {
-                            "output_path": r.output_path,
-                            "status": r.status,
-                            "tracked_changes_found": r.tracked_changes_found,
-                            "tracked_changes_accepted": r.tracked_changes_accepted,
-                            "comments_removed": r.comments_removed,
-                            "comments_kept": r.comments_kept,
-                            "metadata_stripped": r.metadata_stripped,
-                            "warnings": r.warnings,
-                        }
-                    )
-            json_output = {
+        if json_mode:
+            # Batch has no MCP counterpart, so the envelope is CLI-shaped:
+            # here `status` describes the BATCH ("ok"/"failed"), while each
+            # results[] entry carries the per-document verdict under the MCP
+            # tool's field names.
+            json_output: Dict[str, Any] = {
                 "status": "ok" if blocked == 0 else "failed",
                 "outdir": str(outdir),
                 "total": total,
                 "succeeded": succeeded,
                 "blocked": blocked,
-                "results": batch_results,
+                "results": json_results,
             }
             if blocked > 0:
                 json_output["error"] = "batch_failed"

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1454,6 +1454,7 @@ def handle_markup(args):
 
 
 def handle_sanitize(args: argparse.Namespace):
+    _set_json_mode(getattr(args, "json", False))
     from adeu.redline.engine import describe_illegal_control_chars
 
     author_ctrl = describe_illegal_control_chars(args.author or "")
@@ -1529,7 +1530,22 @@ def handle_sanitize(args: argparse.Namespace):
                 if args.report_file:
                     _write_report_file(args.report_file, result.report_text)
 
-            print(f"✅ Sanitized → {output_path}", file=sys.stderr)
+            if getattr(args, "json", False):
+                json_result = {
+                    "status": "ok",
+                    "sanitize_status": result.status,
+                    "input": str(input_path),
+                    "output_path": str(output_path),
+                    "tracked_changes_found": result.tracked_changes_found,
+                    "tracked_changes_accepted": result.tracked_changes_accepted,
+                    "comments_removed": result.comments_removed,
+                    "comments_kept": result.comments_kept,
+                    "metadata_stripped": result.metadata_stripped,
+                    "warnings": result.warnings,
+                }
+                print(json.dumps(json_result))
+            else:
+                print(f"✅ Sanitized → {output_path}", file=sys.stderr)
 
         except SanitizeError as e:
             # Block reason goes to stderr BEFORE the report write: if the
@@ -1538,6 +1554,8 @@ def handle_sanitize(args: argparse.Namespace):
             print(str(e), file=sys.stderr)
             if args.report_file:
                 _write_report_file(args.report_file, str(e))
+            if getattr(args, "json", False):
+                print(json.dumps({"error": "invalid_input", "message": str(e)}))
             sys.exit(1)
         except FileNotFoundError as e:
             _cli_error("file_not_found", str(e))
@@ -1631,11 +1649,13 @@ def handle_sanitize(args: argparse.Namespace):
                     status = "clean"
                     if result.warnings:
                         status = f"clean ({len(result.warnings)} warning{'s' if len(result.warnings) > 1 else ''})"
-                    print(f"  ✓ {input_path.name:<30} — {status}", file=sys.stderr)
+                    if not getattr(args, "json", False):
+                        print(f"  ✓ {input_path.name:<30} — {status}", file=sys.stderr)
 
                 except SanitizeError as e:
                     blocked += 1
-                    print(f"  ✗ {input_path.name:<30} — BLOCKED", file=sys.stderr)
+                    if not getattr(args, "json", False):
+                        print(f"  ✗ {input_path.name:<30} — BLOCKED", file=sys.stderr)
                     all_reports.append(e)
 
                 except Exception as e:
@@ -1644,17 +1664,18 @@ def handle_sanitize(args: argparse.Namespace):
                     # the staged-file cleanup and leaves document content
                     # behind as .staging.tmp files (QA 2026-07-19 v8 F-02).
                     blocked += 1
-                    if (
-                        "bad zip signature" in str(e)
-                        or "not a zip file" in str(e).lower()
-                        or "not a valid DOCX file" in str(e)
-                    ):
-                        print(
-                            f"  ✗ {input_path.name:<30} — ERROR: not a valid DOCX file (bad zip signature)",
-                            file=sys.stderr,
-                        )
-                    else:
-                        print(f"  ✗ {input_path.name:<30} — ERROR: {e}", file=sys.stderr)
+                    if not getattr(args, "json", False):
+                        if (
+                            "bad zip signature" in str(e)
+                            or "not a zip file" in str(e).lower()
+                            or "not a valid DOCX file" in str(e)
+                        ):
+                            print(
+                                f"  ✗ {input_path.name:<30} — ERROR: not a valid DOCX file (bad zip signature)",
+                                file=sys.stderr,
+                            )
+                        else:
+                            print(f"  ✗ {input_path.name:<30} — ERROR: {e}", file=sys.stderr)
 
             if blocked == 0:
                 for staging_path, output_path in staged:
@@ -1678,7 +1699,44 @@ def handle_sanitize(args: argparse.Namespace):
         summary = f"\nBatch Summary: {total} documents processed, {succeeded} succeeded, {blocked} blocked"
         if blocked > 0:
             summary += "\nBatch failed — no outputs were written (the batch is all-or-nothing)."
-        print(summary, file=sys.stderr)
+
+        if getattr(args, "json", False):
+            batch_results: list[dict[str, Any]] = []
+            for r in all_reports:
+                if isinstance(r, SanitizeError):
+                    batch_results.append(
+                        {
+                            "status": "blocked",
+                            "error": str(r),
+                        }
+                    )
+                else:
+                    batch_results.append(
+                        {
+                            "output_path": r.output_path,
+                            "status": r.status,
+                            "tracked_changes_found": r.tracked_changes_found,
+                            "tracked_changes_accepted": r.tracked_changes_accepted,
+                            "comments_removed": r.comments_removed,
+                            "comments_kept": r.comments_kept,
+                            "metadata_stripped": r.metadata_stripped,
+                            "warnings": r.warnings,
+                        }
+                    )
+            json_output = {
+                "status": "ok" if blocked == 0 else "failed",
+                "outdir": str(outdir),
+                "total": total,
+                "succeeded": succeeded,
+                "blocked": blocked,
+                "results": batch_results,
+            }
+            if blocked > 0:
+                json_output["error"] = "batch_failed"
+                json_output["message"] = f"Batch failed: {blocked} of {total} documents blocked"
+            print(json.dumps(json_output))
+        else:
+            print(summary, file=sys.stderr)
 
         # Write reports
         if args.report or args.report_file:
@@ -2018,6 +2076,11 @@ def _main_impl():
         "--report-file",
         type=Path,
         help="Write report to file",
+    )
+    p_sanitize.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit sanitization summary as machine-readable JSON on stdout.",
     )
     p_sanitize.set_defaults(func=handle_sanitize)
 

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -1127,3 +1127,34 @@ def test_post_apply_verification_plain_text_without_heading_prefix(tmp_path, cap
     # 4. Assert that verification passes, return code is 0, and output file is written
     assert code == 0, f"adeu apply failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
     assert out_path.exists(), f"Expected output file {out_path} to be created"
+
+
+def test_cli_sanitize_json_flag(tmp_path, capsys):
+    """
+    Verifies that 'adeu sanitize' accepts the --json flag and emits structured JSON output on stdout.
+    """
+    import json
+
+    import docx
+
+    # 1. Create a minimal test input document
+    input_path = tmp_path / "test_san.docx"
+    output_path = tmp_path / "test_san_clean.docx"
+    doc = docx.Document()
+    doc.add_paragraph("Test document for sanitize JSON output.")
+    doc.save(str(input_path))
+
+    # 2. Invoke adeu sanitize with --json flag
+    code, stdout, stderr = run_cli(
+        ["sanitize", str(input_path), "-o", str(output_path), "--json"],
+        capsys,
+    )
+
+    # 3. Assert success (exit code 0) and that the output document is created
+    assert code == 0, f"adeu sanitize --json failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
+    assert output_path.exists(), f"Expected output document {output_path} to exist"
+
+    # 4. Verify stdout contains valid JSON output
+    data = json.loads(stdout)
+    assert isinstance(data, dict)
+    assert data.get("status") == "ok" or "output_path" in data or "input" in data

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -1154,7 +1154,11 @@ def test_cli_sanitize_json_flag(tmp_path, capsys):
     assert code == 0, f"adeu sanitize --json failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
     assert output_path.exists(), f"Expected output document {output_path} to exist"
 
-    # 4. Verify stdout contains valid JSON output
+    # 4. stdout carries exactly one JSON document describing the sanitization.
+    #    `status` is the DOCUMENT verdict (mirroring the sanitize_docx MCP
+    #    tool), and the payload names both ends of the operation. Full contract
+    #    coverage lives in test_cli_features.py::test_cli_sanitize_json_*.
     data = json.loads(stdout)
-    assert isinstance(data, dict)
-    assert data.get("status") == "ok" or "output_path" in data or "input" in data
+    assert data["status"] in ("clean", "clean_with_warnings")
+    assert data["input"] == str(input_path)
+    assert data["output_path"] == str(output_path)

--- a/python/tests/test_cli_features.py
+++ b/python/tests/test_cli_features.py
@@ -660,6 +660,174 @@ def test_cli_apply_json_validation_error(tmp_path, capsys):
     assert not out_path.exists()
 
 
+# ---------------------------------------------------------------------------
+# `adeu sanitize --json`
+#
+# The payload deliberately mirrors the `sanitize` MCP tool's field names
+# (mcp_components/tools/sanitize.py) so a single parser serves both surfaces:
+# `status` is the DOCUMENT verdict, never an invocation outcome — success is
+# the exit code. These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+# Field-for-field the MCP tool's payload plus the CLI-only `input`.
+_SANITIZE_JSON_KEYS = {
+    "status",
+    "input",
+    "output_path",
+    "tracked_changes_found",
+    "tracked_changes_accepted",
+    "comments_removed",
+    "comments_kept",
+    "metadata_stripped",
+    "warnings",
+    "report_text",
+}
+
+
+def _run_cli(args, capsys):
+    """Invoke the CLI in-process; returns (exit_code, stdout, stderr).
+
+    Mirrors the helper in test_cli_bug_repro.py — the sanitize --json contract
+    is about exit codes AND stream separation, so every assertion needs all
+    three at once.
+    """
+    from unittest.mock import patch
+
+    from adeu.cli import main
+
+    code = 0
+    with patch.object(sys, "argv", ["adeu"] + [str(a) for a in args]):
+        try:
+            main()
+        except SystemExit as e:
+            code = e.code or 0
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+def _make_clean_docx(path: Path, text: str = "A clean paragraph.") -> Path:
+    import docx
+
+    doc = docx.Document()
+    doc.add_paragraph(text)
+    doc.save(str(path))
+    return path
+
+
+def test_cli_sanitize_json_single_file(tmp_path, capsys):
+    input_path = _make_clean_docx(tmp_path / "clean.docx")
+    out_path = tmp_path / "clean_sanitized.docx"
+
+    code, stdout, stderr = _run_cli(["sanitize", input_path, "-o", out_path, "--json"], capsys)
+
+    assert code == 0
+    assert out_path.exists()
+    payload = json.loads(stdout)
+    assert set(payload) == _SANITIZE_JSON_KEYS
+    # `status` is the document verdict, NOT "ok".
+    assert payload["status"] in ("clean", "clean_with_warnings")
+    assert payload["input"] == str(input_path)
+    assert payload["output_path"] == str(out_path)
+    assert payload["tracked_changes_found"] == 0
+    assert isinstance(payload["metadata_stripped"], list)
+    assert "Sanitize Report:" in payload["report_text"]
+    # --json suppresses the decorative success line.
+    assert "✅ Sanitized" not in stderr
+
+
+def test_cli_sanitize_json_blocked_document(tmp_path, capsys):
+    """A refusal is a well-understood outcome: `status: "blocked"` plus the
+    report, the same shape the MCP tool returns — not a malformed-input error."""
+    fixture_path = get_fixture_path("dirty_sample.docx")
+    out_path = tmp_path / "blocked.docx"
+
+    code, stdout, stderr = _run_cli(["sanitize", fixture_path, "-o", out_path, "--json"], capsys)
+
+    assert code == 1
+    assert not out_path.exists()
+    payload = json.loads(stdout)
+    assert payload["status"] == "blocked"
+    assert payload["error"] == "blocked"
+    assert payload["input"] == str(fixture_path)
+    # `message` is the one-line reason, not the whole banner-wrapped report.
+    assert "unresolved tracked changes" in payload["message"]
+    assert "\n" not in payload["message"]
+    assert "BLOCKED:" in payload["report_text"]
+    # The human report still reaches stderr.
+    assert "BLOCKED" in stderr
+
+
+def test_cli_sanitize_json_batch_success(tmp_path, capsys):
+    first = _make_clean_docx(tmp_path / "first.docx")
+    second = _make_clean_docx(tmp_path / "second.docx", "Another clean paragraph.")
+    outdir = tmp_path / "out"
+
+    code, stdout, stderr = _run_cli(["sanitize", first, second, "--outdir", outdir, "--json"], capsys)
+
+    assert code == 0
+    payload = json.loads(stdout)
+    assert payload["status"] == "ok"  # batch-level, unlike the per-document verdict
+    assert (payload["total"], payload["succeeded"], payload["blocked"]) == (2, 2, 0)
+    assert [r["input"] for r in payload["results"]] == [str(first), str(second)]
+    assert all(set(r) == _SANITIZE_JSON_KEYS for r in payload["results"])
+    assert (outdir / "first.docx").exists() and (outdir / "second.docx").exists()
+    assert "Batch Summary" not in stderr
+
+
+def test_cli_sanitize_json_batch_identifies_every_failure(tmp_path, capsys):
+    """Regression: under --json a batch failure used to report only a count —
+    the per-file diagnostics were suppressed on stderr and absent from the
+    payload, so automation could not tell WHICH document failed or why."""
+    good = _make_clean_docx(tmp_path / "good.docx")
+    corrupt = tmp_path / "corrupt.docx"
+    corrupt.write_bytes(b"not a zip file at all")
+    missing = tmp_path / "missing.docx"
+    blocked_doc = get_fixture_path("dirty_sample.docx")
+    outdir = tmp_path / "out"
+
+    code, stdout, stderr = _run_cli(
+        ["sanitize", good, corrupt, missing, blocked_doc, "--outdir", outdir, "--json"],
+        capsys,
+    )
+
+    assert code == 1
+    payload = json.loads(stdout)
+    assert payload["status"] == "failed"
+    assert (payload["total"], payload["succeeded"], payload["blocked"]) == (4, 1, 3)
+    assert payload["error"] == "batch_failed"
+
+    # One entry per input, in input order: len(results) == total always holds.
+    results = payload["results"]
+    assert len(results) == payload["total"]
+    assert [r["input"] for r in results] == [str(good), str(corrupt), str(missing), str(blocked_doc)]
+    assert results[0]["status"] in ("clean", "clean_with_warnings")
+    assert (results[1]["status"], results[1]["error"]) == ("error", "invalid_docx")
+    assert (results[2]["status"], results[2]["error"]) == ("error", "file_not_found")
+    assert (results[3]["status"], results[3]["error"]) == ("blocked", "blocked")
+    assert "unresolved tracked changes" in results[3]["message"]
+
+    # Failures stay on stderr too — --json must never DROP a diagnostic.
+    assert "corrupt.docx" in stderr and "missing.docx" in stderr
+    # All-or-nothing: a failed batch writes no outputs and leaves no staging files.
+    assert list(outdir.glob("*")) == []
+
+
+def test_cli_sanitize_json_rejects_report_on_stdout(tmp_path, capsys):
+    """--json and --report-file - both target stdout; interleaving them would
+    break the one-JSON-document-per-invocation contract (cli-agent-spec §4)."""
+    input_path = _make_clean_docx(tmp_path / "clean.docx")
+
+    code, stdout, stderr = _run_cli(
+        ["sanitize", input_path, "-o", tmp_path / "out.docx", "--json", "--report-file", "-"],
+        capsys,
+    )
+
+    assert code == 2
+    assert stdout == ""
+    assert "mutually exclusive" in stderr
+    assert "report_text" in stderr
+
+
 def test_cli_accept_all_workflow(tmp_path, capsys):
     from io import BytesIO
     from unittest.mock import patch

--- a/skills/adeu-redlining/references/cli-fallback.md
+++ b/skills/adeu-redlining/references/cli-fallback.md
@@ -77,9 +77,14 @@ uvx adeu sanitize redline.docx -o clean.docx --author "My Firm" --report
 
 # Keep redline markup but redact author metadata:
 uvx adeu sanitize redline.docx -o clean.docx --keep-markup --author "My Firm" --report
+
+# Machine-readable result (same fields as the sanitize_docx MCP tool):
+uvx adeu sanitize redline.docx -o clean.docx --json
 ```
 
 Use `--report` to print a sanitization report — useful for verifying what was removed.
+
+With `--json`, stdout carries the same payload as the `sanitize_docx` MCP tool (`status`, `output_path`, `tracked_changes_found`, `tracked_changes_accepted`, `comments_removed`, `comments_kept`, `metadata_stripped`, `warnings`, `report_text`) plus `input`. `status` is the **document verdict** — `clean`, `clean_with_warnings`, or `blocked` — so check the exit code for success, not `status == "ok"`. A document with unresolved tracked changes is refused with `{"status": "blocked", "error": "blocked", "message": "<one-line reason>", "report_text": "<full report>"}` and exit 1 — re-run with `--accept-all` or `--keep-markup`. Batch mode (`--outdir`) returns `{"status": "ok"|"failed", "outdir", "total", "succeeded", "blocked", "results"}` with one `results` entry per input, in input order, each naming its `input` — so a failed batch tells you exactly which documents failed and why. Batches are all-or-nothing: any failure means no outputs were written. Do not combine `--json` with `--report-file -` (both write to stdout); the report is already in `report_text`.
 
 ### `adeu accept-all` — accept every change and drop every comment
 


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
[05:37:15] I have fixed the issue where `adeu sanitize` was missing support for the `--json` flag.
[05:37:15] 
[05:37:15] ### Root Cause
[05:37:16] In `src/adeu/cli.py`, the `p_sanitize` argument parser definition lacked the `--json` flag, and `handle_sanitize` did not format its response payload as structured JSON on stdout when requested, causing `argparse` to report `unrecognized arguments: --json` with exit code 2.
[05:37:16] 
[05:37:16] ### Fix
[05:37:16] 1. Added `--json` argument definition to `p_sanitize` in `src/adeu/cli.py`.
[05:37:16] 2. Updated `handle_sanitize` in `src/adeu/cli.py`:
[05:37:16]    - Configured global JSON output mode via `_set_json_mode`.
[05:37:16]    - Handled single-file and batch sanitization modes to emit structured JSON summaries on stdout when `--json` is active.
[05:37:16]    - Suppressed decorative stderr messages on `--json` success paths in accordance with unified CLI stream conventions.
[05:37:16] 
[05:37:16] ### Verification
[05:37:16] - Verified with `uv run pytest tests/test_cli_bug_repro.py::test_cli_sanitize_json_flag` (PASSED).
[05:37:16] - Verified full test suite with `uv run pytest` (969 passed, 0 failed).


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description & Severity
**Severity:** S2 (Broken feature / Inconsistent CLI interface across subcommands)
The `adeu sanitize` subcommand lacks support for the `--json` flag, unlike all other primary CLI processing subcommands (`extract`, `diff`, `apply`, `accept-all`, `markup`) which implement `--json` to output machine-readable JSON metadata on stdout. When invoked with `--json`, `adeu sanitize` fails immediately during argument parsing with exit code `2` and reports `adeu sanitize: error: unrecognized arguments: --json`. This prevents automated agentic workflows and scripts from executing document sanitization and receiving structured execution results.

### Minimal Reproduction
1. Create a minimal input document:
```bash
python -c "import docx; doc = docx.Document(); doc.add_paragraph('Test document.'); doc.save('test_san.docx')"
```

2. Run `adeu sanitize` with `--json`:
```bash
adeu sanitize test_san.docx -o test_san_clean.docx --json
```

**Observed Output:**
```
usage: adeu sanitize [-h] [-o OUTPUT] [--outdir OUTDIR] [--keep-markup]
                     [--baseline BASELINE] [--allow-low-similarity-baseline]
                     [--author AUTHOR] [--accept-all] [--report]
                     [--report-file REPORT_FILE]
                     input [input ...]
adeu sanitize: error: unrecognized arguments: --json
```
Exit code: `2`

### Full Test Code
Added `test_cli_sanitize_json_flag` to `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py`:

```python
def test_cli_sanitize_json_flag(tmp_path, capsys):
    """
    Verifies that 'adeu sanitize' accepts the --json flag and emits structured JSON output on stdout.
    """
    import json
    import docx

    # 1. Create a minimal test input document
    input_path = tmp_path / "test_san.docx"
    output_path = tmp_path / "test_san_clean.docx"
    doc = docx.Document()
    doc.add_paragraph("Test document for sanitize JSON output.")
    doc.save(str(input_path))

    # 2. Invoke adeu sanitize with --json flag
    code, stdout, stderr = run_cli(
        ["sanitize", str(input_path), "-o", str(output_path), "--json"],
        capsys,
    )

    # 3. Assert success (exit code 0) and that the output document is created
    assert code == 0, f"adeu sanitize --json failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
    assert output_path.exists(), f"Expected output document {output_path} to exist"

    # 4. Verify stdout contains valid JSON output
    data = json.loads(stdout)
    assert isinstance(data, dict)
    assert data.get("status") == "ok" or "output_path" in data or "input" in data
```

### Pytest Failure Output
```
=================================== FAILURES ===================================
_________________________ test_cli_sanitize_json_flag __________________________

tmp_path = PosixPath('/private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-125/popen-gw3/test_cli_sanitize_json_flag0')
capsys = <_pytest.capture.CaptureFixture object at 0x10b50de80>

    def test_cli_sanitize_json_flag(tmp_path, capsys):
        """
        Verifies that 'adeu sanitize' accepts the --json flag and emits structured JSON output on stdout.
        """
        import json
        import docx
    
        # 1. Create a minimal test input document
        input_path = tmp_path / "test_san.docx"
        output_path = tmp_path / "test_san_clean.docx"
        doc = docx.Document()
        doc.add_paragraph("Test document for sanitize JSON output.")
        doc.save(str(input_path))
    
        # 2. Invoke adeu sanitize with --json flag
        code, stdout, stderr = run_cli(
            ["sanitize", str(input_path), "-o", str(output_path), "--json"],
            capsys,
        )
    
        # 3. Assert success (exit code 0) and that the output document is created
>       assert code == 0, f"adeu sanitize --json failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
E       AssertionError: adeu sanitize --json failed with code 2.
E         STDERR:
E         usage: adeu sanitize [-h] [-o OUTPUT] [--outdir OUTDIR] [--keep-markup]
E                              [--baseline BASELINE] [--allow-low-similarity-baseline]
E                              [--author AUTHOR] [--accept-all] [--report]
E                              [--report-file REPORT_FILE]
E                              input [input ...]
E         adeu sanitize: error: unrecognized arguments: --json
E         
E         STDOUT:
E         
E       assert 2 == 0

tests/test_cli_bug_repro.py:1153: AssertionError
=========================== short test summary info ============================
FAILED tests/test_cli_bug_repro.py::test_cli_sanitize_json_flag - AssertionError: adeu sanitize --json failed with code 2.
============ 1 failed, 968 passed, 39 skipped, 3 warnings in 10.72s ============
```

### Expected Behavior Once Fixed
When `adeu sanitize ... --json` is executed on valid input DOCX files:
- The command exits with status code `0`.
- The sanitized DOCX output file is created/written as specified.
- The command outputs valid JSON on stdout summarizing the sanitization result (e.g., `status`, input path, output path, and sanitization metrics).


</details>
