### PR TITLE
fix: report 0 applied edits on post-apply verification failure

### DIFF
--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -1202,6 +1202,20 @@ def handle_apply(args):
             )
             stats["verified"] = False
             stats["verification_error"] = verification_error
+
+            # Post-apply verification failed: no output was written to the requested destination.
+            # Re-mark stats and edit reports so they accurately reflect 0 applied edits/actions.
+            stats["edits_skipped"] = stats.get("edits_applied", 0) + stats.get("edits_skipped", 0)
+            stats["edits_applied"] = 0
+            stats["actions_skipped"] = stats.get("actions_applied", 0) + stats.get("actions_skipped", 0)
+            stats["actions_applied"] = 0
+
+            if stats.get("edits"):
+                for report in stats["edits"]:
+                    report["status"] = "failed"
+                    report["error"] = "Not applied: post-apply verification failed."
+                    report["critic_markup"] = None
+                    report["clean_text"] = None
         else:
             stats["verified"] = True
 

--- a/python/tests/test_cli_bug_repro.py
+++ b/python/tests/test_cli_bug_repro.py
@@ -1127,3 +1127,73 @@ def test_post_apply_verification_plain_text_without_heading_prefix(tmp_path, cap
     # 4. Assert that verification passes, return code is 0, and output file is written
     assert code == 0, f"adeu apply failed with code {code}.\nSTDERR:\n{stderr}\nSTDOUT:\n{stdout}"
     assert out_path.exists(), f"Expected output file {out_path} to be created"
+
+
+def test_post_apply_verification_failure_edit_reports(tmp_path, capsys):
+    """
+    Verifies that when post-apply verification fails in `adeu apply`, the CLI report
+    and JSON stats accurately state that 0 edits were applied and no edits are falsely
+    logged as applied.
+    """
+    import json
+
+    import docx
+
+    # 1. Create a document with headings and paragraphs
+    doc_path = tmp_path / "doc_basic.docx"
+    doc = docx.Document()
+    doc.add_heading("Master Services Agreement", level=1)
+    doc.add_paragraph("1. Definitions")
+    doc.add_paragraph("1.1 Services means consulting services.")
+    doc.add_paragraph("1.2 Term means 24 months.")
+    doc.add_paragraph("2. Compensation")
+    doc.add_paragraph("2.1 Client shall pay $10,000 USD.")
+    doc.save(str(doc_path))
+
+    # 2. Create a modified text file that omits heading markup (# )
+    txt_path = tmp_path / "modified_text.txt"
+    txt_path.write_text(
+        "Master Services Agreement\n"
+        "1. Definitions\n"
+        "1.1 Services means consulting services.\n"
+        "1.2 Term means 24 months.\n"
+        "2. Compensation\n"
+        "2.1 Client shall pay $15,000 USD.\n",
+        encoding="utf-8",
+    )
+
+    out_path = tmp_path / "output.docx"
+
+    # 3. Run adeu apply (human-readable / stderr mode)
+    code, stdout, stderr = run_cli(
+        ["apply", str(doc_path), str(txt_path), "-o", str(out_path)],
+        capsys,
+    )
+
+    # 4. Assert verification failure and exit code 1
+    assert code == 1, f"Expected non-zero exit code on verification failure, got {code}"
+    assert not out_path.exists(), f"Output file {out_path} should not be written when verification fails"
+    assert "Verification failed" in stderr or "verification failed" in stderr
+
+    # 5. Assert report accuracy: must NOT claim edits were applied
+    assert "Edits: 0 applied" in stderr or "0 applied" in stderr, (
+        f"CLI report should state 0 edits applied when verification fails, got:\n{stderr}"
+    )
+    assert "✅ [applied]" not in stderr, (
+        f"CLI report falsely marked edits as applied on verification failure:\n{stderr}"
+    )
+
+    # 6. Run adeu apply with --json
+    out_json_path = tmp_path / "output_json.docx"
+    code_json, stdout_json, stderr_json = run_cli(
+        ["apply", str(doc_path), str(txt_path), "-o", str(out_json_path), "--json"],
+        capsys,
+    )
+
+    assert code_json == 1
+    assert not out_json_path.exists()
+    stats = json.loads(stdout_json)
+    assert stats.get("verified") is False
+    assert stats.get("edits_applied") == 0, (
+        f"JSON stats edits_applied should be 0 on verification failure, got {stats.get('edits_applied')}"
+    )


### PR DESCRIPTION
## Agentic Auto-Fix (CLI (adeu))

This PR was generated autonomously by the `agy` testing loop.

### Fix Report
### Root Cause
In `adeu apply`, when applying a text-file diff against a DOCX document, `engine.process_batch()` executes the diff edits in memory and populates `stats` with `edits_applied: N` and `status: "applied"` for each edit. When post-apply verification subsequently extracts the applied document's clean text and compares it against the supplied text, structural remnants (such as heading markers or table skeletons that cannot be removed by text replacements) may cause verification to fail. 

When verification failed, `src/adeu/cli.py` correctly created a diagnostic `.unverified.docx` copy and aborted writing to the requested output path (`stats["output_path"] = None`). However, it failed to update `stats["edits_applied"]`, `stats["edits_skipped"]`, `stats["actions_applied"]`, `stats["actions_skipped"]`, or the individual edit reports in `stats["edits"]`. As a result, the CLI stderr summary printed `Edits: N applied, 0 skipped` and `Edit N ✅ [applied]`, and `--json` reported `"edits_applied": N`, falsely logging that edits succeeded when in reality 0 edits were committed and no output file was produced.

### The Fix
Modified `handle_apply` in [src/adeu/cli.py](file:///Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/src/adeu/cli.py) within the post-apply verification failure branch (`if actual_norm != expected_norm:`):
- Re-marked batch statistics:
  - `stats["edits_skipped"] = stats.get("edits_applied", 0) + stats.get("edits_skipped", 0)`
  - `stats["edits_applied"] = 0`
  - `stats["actions_skipped"] = stats.get("actions_applied", 0) + stats.get("actions_skipped", 0)`
  - `stats["actions_applied"] = 0`
- Updated individual edit reports in `stats["edits"]`:
  - Set `report["status"] = "failed"`
  - Set `report["error"] = "Not applied: post-apply verification failed."`
  - Cleared `critic_markup` and `clean_text` previews so failed edits are not reported with misleading success previews.

This aligns CLI post-apply verification failure reporting with the `RedlineEngine`'s existing transactional failure model and guarantees that both human-readable stderr reports and `--json` stats accurately reflect 0 applied edits when verification fails.

### Sibling Occurrences & Parity
- **MCP & Disk Processing:** Inspected `_process_document_batch_disk` in `src/adeu/mcp_components/tools/document.py`. Post-apply text-file verification is specific to the CLI `apply` command when diffing an explicit text file against a `.docx`.
- **Engine Transactional Alignment:** Checked `RedlineEngine._process_batch_internal` in `src/adeu/redline/engine.py`. The engine's internal batch failure handling already resets `applied_edits = 0` and sets `status = "failed"` on validation error; the CLI's post-apply verification failure path now follows the exact same reporting pattern.

### Verification
From `/Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python`:
1. **Targeted Regression Test:**
   - `uv run pytest tests/test_cli_bug_repro.py` -> **24 passed** (including `test_post_apply_verification_failure_edit_reports`).
2. **Full Test Suite:**
   - `uv run pytest` -> **1016 passed, 39 skipped** (0 failures).
3. **Linter & Formatter:**
   - `uv run ruff check --fix .` -> **Clean** (1 error auto-fixed).
   - `uv run ruff format .` -> **Clean** (1 file reformatted).
4. **Type Check:**
   - `uv run mypy src` -> **Clean** (Success: no issues found in 31 source files).
5. **Node.js Package Consistency:**
   - `cd node && npm install && npm run build && npm test` -> Verified build and test suite pass.

### Risk Assessment & Follow-ups
- **Risk:** Low. The fix is strictly localized to the error reporting block when `adeu apply` post-apply verification fails. Successful file applications and dry-run simulations remain completely untouched.
- **Follow-up:** Keep `edits_applied` synchronized with actual filesystem writes across any future verification or post-processing pipeline steps.


<details><summary>Reproduction Report</summary>

REPRO_CONFIRMED: /Users/mkorpela/workspace/agy-loop/workspaces/cli_reproduce/adeu_isolated/python/tests/test_cli_bug_repro.py

### Bug Description
In `adeu apply`, when post-apply verification fails (for example, when applying a text-file diff that attempts to alter heading structures that cannot be realized cleanly in OpenXML), the command aborts, writes no output document to the requested `-o` path, and exits with code 1. However, the human-readable CLI report on stderr and the JSON stats payload on stdout both falsely claim that edits were applied (`Edits: 7 applied, 0 skipped`, `Edit 1 ✅ [applied]`, and `stats["edits_applied"]: 7`). This false-positive status logging misleads automated LLM agents and downstream tools into assuming that redline edits succeeded on the output file when in reality 0 edits were committed and no output file was created.
**Severity:** S2 (Inconsistent status reporting & misleading CLI logs).

### Minimal Reproduction
From scratch experiments:
1. **Input DOCX (`doc_basic.docx`):** Standard DOCX containing heading `# Master Services Agreement` and numbered clauses.
2. **Input Modified Text (`modified_text.txt`):** Plain text omitting heading markers (`# `):
   ```text
   Master Services Agreement
   1. Definitions
   1.1 Services means consulting services.
   1.2 Term means 24 months.
   2. Compensation
   2.1 Client shall pay $15,000 USD.
   ```
3. **Execution Command:**
   ```bash
   adeu apply doc_basic.docx modified_text.txt -o output.docx
   ```
4. **Observed Output:**
   Post-apply verification fails and `output.docx` is not written (exit code 1), yet the CLI outputs:
   ```text
   ❌ Verification failed — no output was written to: output.docx
      A diagnostic copy (NOT the requested document) was kept at: output.unverified.docx
   Actions: 0 applied, 0 skipped.
   Edits: 7 applied, 0 skipped.

   Detailed Edit Reports:
   Edit 1 ✅ [applied]:
     Target: '# '
     New text: ''
     ...
   ```

### Full Test Code
```python
def test_post_apply_verification_failure_edit_reports(tmp_path, capsys):
    """
    Verifies that when post-apply verification fails in `adeu apply`, the CLI report
    and JSON stats accurately state that 0 edits were applied and no edits are falsely
    logged as applied.
    """
    import json
    import docx

    # 1. Create a document with headings and paragraphs
    doc_path = tmp_path / "doc_basic.docx"
    doc = docx.Document()
    doc.add_heading("Master Services Agreement", level=1)
    doc.add_paragraph("1. Definitions")
    doc.add_paragraph("1.1 Services means consulting services.")
    doc.add_paragraph("1.2 Term means 24 months.")
    doc.add_paragraph("2. Compensation")
    doc.add_paragraph("2.1 Client shall pay $10,000 USD.")
    doc.save(str(doc_path))

    # 2. Create a modified text file that omits heading markup (# )
    txt_path = tmp_path / "modified_text.txt"
    txt_path.write_text(
        "Master Services Agreement\n"
        "1. Definitions\n"
        "1.1 Services means consulting services.\n"
        "1.2 Term means 24 months.\n"
        "2. Compensation\n"
        "2.1 Client shall pay $15,000 USD.\n",
        encoding="utf-8",
    )

    out_path = tmp_path / "output.docx"

    # 3. Run adeu apply (human-readable / stderr mode)
    code, stdout, stderr = run_cli(
        ["apply", str(doc_path), str(txt_path), "-o", str(out_path)],
        capsys,
    )

    # 4. Assert verification failure and exit code 1
    assert code == 1, f"Expected non-zero exit code on verification failure, got {code}"
    assert not out_path.exists(), f"Output file {out_path} should not be written when verification fails"
    assert "Verification failed" in stderr or "verification failed" in stderr

    # 5. Assert report accuracy: must NOT claim edits were applied
    assert "Edits: 0 applied" in stderr or "0 applied" in stderr, (
        f"CLI report should state 0 edits applied when verification fails, got:\n{stderr}"
    )
    assert "✅ [applied]" not in stderr, (
        f"CLI report falsely marked edits as applied on verification failure:\n{stderr}"
    )

    # 6. Run adeu apply with --json
    out_json_path = tmp_path / "output_json.docx"
    code_json, stdout_json, stderr_json = run_cli(
        ["apply", str(doc_path), str(txt_path), "-o", str(out_json_path), "--json"],
        capsys,
    )

    assert code_json == 1
    assert not out_json_path.exists()
    stats = json.loads(stdout_json)
    assert stats.get("verified") is False
    assert stats.get("edits_applied") == 0, (
        f"JSON stats edits_applied should be 0 on verification failure, got {stats.get('edits_applied')}"
    )
```

### Pytest Failure Output
```text
_____________________ test_post_apply_verification_failure_edit_reports _____________________

    def test_post_apply_verification_failure_edit_reports(tmp_path, capsys):
        ...
        # 5. Assert report accuracy: must NOT claim edits were applied
        assert "Edits: 0 applied" in stderr or "0 applied" in stderr, (
            f"CLI report should state 0 edits applied when verification fails, got:\n{stderr}"
        )
>       assert "✅ [applied]" not in stderr, (
            f"CLI report falsely marked edits as applied on verification failure:\n{stderr}"
        )
E       AssertionError: CLI report falsely marked edits as applied on verification failure:
E         Calculating diff from text file /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-148/popen-gw3/test_post_apply_verification_f0/modified_text.txt...
E         Applying 7 changes to doc_basic.docx...
E         ❌ Verification failed — no output was written to: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-148/popen-gw3/test_post_apply_verification_f0/output.docx
E            A diagnostic copy (NOT the requested document) was kept at: /private/var/folders/f_/4188wkyx70qdzw_gb54ll20w0000gq/T/pytest-of-mkorpela/pytest-148/popen-gw3/test_post_apply_verification_f0/output.unverified.docx
E         Actions: 0 applied, 0 skipped.
E         Edits: 7 applied, 0 skipped.
E         
E         Detailed Edit Reports:
E         Edit 1 ✅ [applied]:
E           Target: '# '
E           New text: ''
E           ...
E         Edit 7 ✅ [applied]:
E           Target: '10'
E           New text: '15'
E           ...
E         
E         ❌ Post-apply verification failed: the applied document's clean text does not match the supplied text...
```

### Expected Behavior Once Fixed
When post-apply verification fails during `adeu apply`, the batch is aborted, no document is saved to the target `-o output.docx` path, and the CLI execution completes with exit status 1. The edit summary report printed to stderr and the structured JSON output returned via `--json` must accurately reflect that 0 edits were applied to the destination file (`Edits: 0 applied` and `stats["edits_applied"]: 0`). Individual edit statuses in the report should reflect the verification failure rather than falsely claiming `Edit N ✅ [applied]`.


</details>
