### PR TITLE
feat(python): make fastmcp an optional extra (adeu[mcp])

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,11 +24,19 @@ dependencies = [
     "pydantic>=2.0.0",
     "lxml>=5.0.0",
     "diff-match-patch>=20230430",
-    "fastmcp[apps]>=3.1.1",
     "jinja2>=3.1.6",
     "pywin32; sys_platform == 'win32'",
     "rapidfuzz>=3.14.5",
     "regex>=2024.11.6",
+]
+
+[project.optional-dependencies]
+# The MCP server (adeu-server) and the CLI's --live Word integration need
+# fastmcp. The plain CLI (extract/diff/apply/markup/sanitize) does not — it
+# already avoids importing fastmcp at runtime (see _response_builders.py);
+# this extra keeps its ~20 transitive packages out of CLI-only installs too.
+mcp = [
+    "fastmcp[apps]>=3.1.1",
 ]
 
 [project.urls]
@@ -52,6 +60,10 @@ dev = [
     "hypothesis",
     "pytest-cov>=7.1.0",
     "pytest-xdist>=3.8.0",
+    # The test suite exercises the MCP server, so a plain `uv sync` must
+    # bring in the 'mcp' extra's dependency even though runtime installs
+    # keep it optional. Keep this pin in step with the extra above.
+    "fastmcp[apps]>=3.1.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/python/src/adeu/cli.py
+++ b/python/src/adeu/cli.py
@@ -180,7 +180,8 @@ def _cli_error(code: str, message: str, exit_code: int = 1, hint: "str | None" =
       - a single {"error": code, "message": ...} JSON object on stdout when
         the invocation asked for --json
     Stable codes: file_not_found, invalid_input, invalid_docx,
-    invalid_changes_file, write_failed, unsupported, batch_validation_failed.
+    invalid_changes_file, write_failed, unsupported, batch_validation_failed,
+    missing_dependency.
     """
     print(f"❌ {message}", file=sys.stderr)
     if hint:
@@ -188,6 +189,19 @@ def _cli_error(code: str, message: str, exit_code: int = 1, hint: "str | None" =
     if _JSON_MODE:
         print(json.dumps({"error": code, "message": message}))
     sys.exit(exit_code)
+
+
+def _missing_mcp_extra_and_exit(exc: ImportError) -> None:
+    """
+    The --live Word integration rides on the MCP tool layer, and fastmcp is
+    an optional extra so CLI-only installs stay lean. Turn the raw
+    ImportError into the standard CLI error contract.
+    """
+    _cli_error(
+        "missing_dependency",
+        f"--live requires the optional MCP dependencies (missing module: {exc.name}).",
+        hint="Install them with: pip install 'adeu[mcp]'",
+    )
 
 
 def _print_sandbox_warning_and_exit(path: Path, exit_code: int = 1):
@@ -695,7 +709,10 @@ def handle_extract(args):
     if args.live:
         if sys.platform != "win32":
             _cli_error("unsupported", "--live is only supported on Windows.")
-        from adeu.mcp_components.tools.live_word import _read_active_word_document_core
+        try:
+            from adeu.mcp_components.tools.live_word import _read_active_word_document_core
+        except ImportError as exc:
+            _missing_mcp_extra_and_exit(exc)
 
         text, doc, paragraph_offsets = _read_active_word_document_core(clean_view=args.clean_view)
     else:
@@ -1064,9 +1081,12 @@ def handle_apply(args):
         if args.live:
             if sys.platform != "win32":
                 _cli_error("unsupported", "--live is only supported on Windows.")
-            from adeu.mcp_components.tools.live_word import (
-                _read_active_word_document_core,
-            )
+            try:
+                from adeu.mcp_components.tools.live_word import (
+                    _read_active_word_document_core,
+                )
+            except ImportError as exc:
+                _missing_mcp_extra_and_exit(exc)
 
             text_orig, _, _ = _read_active_word_document_core(clean_view=False)
         else:
@@ -1109,7 +1129,10 @@ def handle_apply(args):
     if args.live:
         if sys.platform != "win32":
             _cli_error("unsupported", "--live is only supported on Windows.")
-        from adeu.mcp_components.tools.live_word import _process_active_word_batch_core
+        try:
+            from adeu.mcp_components.tools.live_word import _process_active_word_batch_core
+        except ImportError as exc:
+            _missing_mcp_extra_and_exit(exc)
 
         if not args.json:
             print(f"Applying {len(changes)} changes to live Word document...", file=sys.stderr)

--- a/python/src/adeu/server.py
+++ b/python/src/adeu/server.py
@@ -4,10 +4,18 @@ import sys
 from pathlib import Path
 
 import structlog
-from fastmcp import FastMCP
-from fastmcp.server.providers import FileSystemProvider
-from fastmcp.utilities.types import Image
-from mcp.types import Icon
+
+try:
+    from fastmcp import FastMCP
+    from fastmcp.server.providers import FileSystemProvider
+    from fastmcp.utilities.types import Image
+    from mcp.types import Icon
+except ImportError as _exc:
+    raise SystemExit(
+        "adeu-server requires the MCP server dependencies, which are an "
+        "optional extra. Install them with: pip install 'adeu[mcp]' "
+        f"(missing: {_exc.name})"
+    ) from _exc
 
 from adeu.mcp_components.shared import get_build_info
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -15,7 +15,6 @@ version = "1.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "diff-match-patch" },
-    { name = "fastmcp", extra = ["apps"] },
     { name = "jinja2" },
     { name = "lxml" },
     { name = "pydantic" },
@@ -26,8 +25,14 @@ dependencies = [
     { name = "structlog" },
 ]
 
+[package.optional-dependencies]
+mcp = [
+    { name = "fastmcp", extra = ["apps"] },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "fastmcp", extra = ["apps"] },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
@@ -39,7 +44,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "diff-match-patch", specifier = ">=20230430" },
-    { name = "fastmcp", extras = ["apps"], specifier = ">=3.1.1" },
+    { name = "fastmcp", extras = ["apps"], marker = "extra == 'mcp'", specifier = ">=3.1.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -49,9 +54,11 @@ requires-dist = [
     { name = "regex", specifier = ">=2024.11.6" },
     { name = "structlog", specifier = ">=24.0.0" },
 ]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fastmcp", extras = ["apps"], specifier = ">=3.1.1" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1870,8 +1877,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Moves `fastmcp[apps]` from core `dependencies` to an optional `mcp` extra, so CLI-only installs stay lean:

| install | packages | site-packages |
|---|---|---|
| `pip install adeu` | 15 | 55 MB |
| `pip install 'adeu[mcp]'` | 77 | 144 MB |

## Why

The v6 QA fix (M6, 26d2fc4) already made the response builders framework-free so `adeu extract` doesn't *import* fastmcp at runtime — this finishes the thought by keeping its ~60 transitive packages (starlette, uvicorn, authlib, pyjwt, ...) out of the *install* for users who only want the CLI (`extract`/`diff`/`apply`/`markup`/`sanitize`).

## Behavior without the extra

- `adeu-server` exits 1 with `Install them with: pip install 'adeu[mcp]'` instead of an ImportError traceback.
- The CLI's `--live` Word paths (the only CLI feature riding on the MCP tool layer) report a stable `missing_dependency` error through the `_cli_error` contract (stderr + `--json` object), added to the stable-codes list.
- `adeu init` still works — it only writes host config.

## Dev/CI

- `dev` dependency group pins `fastmcp[apps]>=3.1.1` so a plain `uv sync` still provisions the full test suite (with a comment to keep it in step with the extra).
- CI already uses `uv sync --all-extras --dev`; the release job only builds. No workflow changes needed.
- `uv.lock` regenerated.

## Testing

- Full suite: 1023 passed, 42 skipped (includes the structural no-fastmcp-in-sys.modules guard from M6).
- Fresh-venv verification: `pip install ./python` (no extra) → `import fastmcp` fails, `adeu extract` works on `shared/fixtures/golden.docx`, `adeu-server` exits 1 with the friendly message; `pip install './python[mcp]'` → server imports fine.
- ruff check, ruff format, mypy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)