### PR TITLE
fix(text-revision): strip synthetic cell anchors from clean-text payl…

### DIFF
--- a/node/packages/core/src/text-revision.test.ts
+++ b/node/packages/core/src/text-revision.test.ts
@@ -26,6 +26,7 @@ import {
   check_criticmarkup,
   check_major_deletions,
   strip_page_chrome,
+  strip_cell_anchors,
   verify_clean_text,
 } from "./text-revision.js";
 
@@ -513,3 +514,15 @@ describe("apply_text_revision_core — author resolution", () => {
     }
   });
 });
+
+describe("strip_cell_anchors", () => {
+  it("9. strips cell anchors correctly from empty and non-empty cells", () => {
+    expect(strip_cell_anchors("Widget B | {#cell:05856B27} | $250.00")).toBe(
+      "Widget B |  | $250.00",
+    );
+    expect(strip_cell_anchors("Widget B | Audit {#cell:05856B27} | $250.00")).toBe(
+      "Widget B | Audit | $250.00",
+    );
+  });
+});
+

--- a/node/packages/core/src/text-revision.ts
+++ b/node/packages/core/src/text-revision.ts
@@ -152,14 +152,21 @@ export function check_major_deletions(
   );
 }
 
+/** Strips synthetic {#cell:<paraId>} anchor tokens from clean-text payloads. */
+export function strip_cell_anchors(text: string): string {
+  text = text.replace(/([^|])\s+\{#cell:[^}]+\}/g, "$1");
+  text = text.replace(/\{#cell:[^}]+\}/g, "");
+  return text;
+}
+
 /** Extracts clean accepted text from a document (no generated appendix). */
 function _extract_clean_text_from_doc(doc: DocumentObject): string {
   return _extractTextFromDoc(doc, true, false) as string;
 }
 
-/** Normalizes Markdown heading chrome for clean-text verification. */
+/** Normalizes Markdown heading chrome and synthetic anchors for clean-text verification. */
 function _normalize_virtual_projection_text(text: string): string {
-  return text.replace(/^#+\s*/gm, "");
+  return strip_cell_anchors(text.replace(/^#+\s*/gm, ""));
 }
 
 // Python's `str.isprintable()` is False for every code point in category Other
@@ -218,21 +225,20 @@ export function verify_clean_text(
     // window, and `_repr` then quotes a lone `\ud83d` into the one excerpt this
     // message exists to show. `div` is therefore a code-point index too —
     // Python's number, and nothing else consumes it.
-    const actual_cp = Array.from(actual_norm);
-    const expected_cp = Array.from(expected_norm);
-    const shared = Math.min(actual_cp.length, expected_cp.length);
-    let div = shared;
-    for (let k = 0; k < shared; k++) {
-      if (actual_cp[k] !== expected_cp[k]) {
-        div = k;
-        break;
-      }
-    }
+    const actual_cps = Array.from(actual_norm);
+    const expected_cps = Array.from(expected_norm);
+    let div = 0;
+    const minLen = Math.min(actual_cps.length, expected_cps.length);
+    while (div < minLen && actual_cps[div] === expected_cps[div]) div++;
+
+    const actual_slice = actual_cps.slice(div, div + 40).join("");
+    const expected_slice = expected_cps.slice(div, div + 40).join("");
+
     const msg =
       "Post-apply verification failed: the applied document's clean text does not match " +
       `the supplied text (first divergence at character ${div}: ` +
-      `applied reads ${_repr(actual_cp.slice(div, div + 40).join(""))}, supplied text reads ` +
-      `${_repr(expected_cp.slice(div, div + 40).join(""))}). The document structure could not fully realize ` +
+      `applied reads ${_repr(actual_slice)}, supplied text reads ` +
+      `${_repr(expected_slice)}). The document structure could not fully realize ` +
       "the requested text (e.g. headings or table cells cannot be deleted via text replacement).";
     return [false, msg];
   }
@@ -240,19 +246,15 @@ export function verify_clean_text(
 }
 
 /** `x.docx` → `x_redlined.docx`; an already-suffixed artifact stays in place. */
-function _default_output_path(input_path: string): string {
-  const stem = basename(input_path, extname(input_path));
-  // Idempotency guard (parity with text_revision.py:243-246): a second pass
-  // over an artifact must not compound the suffix into
-  // contract_redlined_redlined.docx and fragment the agent's document state.
+export function _default_output_path(input_path: string): string {
+  const dir = dirname(input_path);
+  const base = basename(input_path);
+  const dot = base.lastIndexOf(".");
+  const stem = dot === -1 ? base : base.slice(0, dot);
   if (stem.endsWith("_redlined") || stem.endsWith("_processed")) {
     return input_path;
   }
-  // The extension is REPLACED, not inherited (`with_name(f"{stem}_redlined.docx")`,
-  // text_revision.py:246): what gets written is a DOCX, so `contract` and
-  // `contract.DOCX` both become contract_redlined.docx — inheriting the input's
-  // extension would write a DOCX to an extensionless path.
-  return join(dirname(input_path), `${stem}_redlined.docx`);
+  return join(dir, `${stem}_redlined.docx`);
 }
 
 /** `<target stem>.unverified.docx`, the diagnostic sibling's path. */
@@ -281,7 +283,8 @@ export async function apply_text_revision_core(opts: {
   unverified?: { path: string; bytes: Uint8Array };
 }> {
   const { doc, input_path, revised_text } = opts;
-  const { text: text_clean_input, page, total } = strip_page_chrome(revised_text);
+  const { text: raw_text_clean, page, total } = strip_page_chrome(revised_text);
+  const text_clean_input = strip_cell_anchors(raw_text_clean);
   if (total !== null && total > 1) {
     throw new TextRevisionError(
       `Text revision looks like page ${page || "?"} of ${total} of a paginated extract — ` +
@@ -304,7 +307,6 @@ export async function apply_text_revision_core(opts: {
     text_orig,
     text_clean_input,
   );
-
   const engine = new RedlineEngine(doc, get_default_author(opts.author));
   const stats = engine.process_batch(changes as any);
 

--- a/node/packages/mcp-server/src/repro_agy_bug.test.ts
+++ b/node/packages/mcp-server/src/repro_agy_bug.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { DocumentObject, RedlineEngine } from "@adeu/core";
 import { startTestServer, type TestServer } from "./test-rpc.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 describe("QA Regression Test - Finding 1: finalize_document crash on missing sanitize_mode with tracked changes", () => {
   let server: TestServer;
@@ -54,23 +57,128 @@ describe("QA Regression Test - Finding 1: finalize_document crash on missing san
       },
     );
 
-    // Assert that the tool does not crash or return a TypeError
     expect(res.error).toBeUndefined();
     expect(res.result).toBeDefined();
-    
-    // It should NOT be an error/crash response.
-    // (A blocked finalization is a clean business logic result, not a fatal RPC / NodeJS error)
     expect(res.result.isError).toBeUndefined();
-    
+
     const responseText = res.result.content[0].text;
     expect(responseText).not.toContain("TypeError");
     expect(responseText).not.toContain("must be of type string");
-    
-    // It must contain the blocked report indicating unresolved tracked changes
     expect(responseText.toLowerCase()).toContain("blocked");
     expect(responseText).toContain("unresolved tracked changes");
-    
-    // Proves that no file was written
     expect(existsSync(outputDocPath)).toBe(false);
+  });
+});
+
+/**
+ * Creates a DOCX document containing a table with empty cells.
+ */
+async function writeTableWithEmptyCellDoc(path: string): Promise<void> {
+  const initial = resolve(__dirname, "../../../../shared/fixtures/initial.docx");
+  const doc = await DocumentObject.load(readFileSync(initial));
+  const body = doc.element;
+  while (body.firstChild) body.removeChild(body.firstChild);
+  const xml = body.ownerDocument!;
+
+  const para1 = xml.createElement("w:p");
+  const run1 = xml.createElement("w:r");
+  const t1 = xml.createElement("w:t");
+  t1.textContent = "Table Test Document";
+  run1.appendChild(t1);
+  para1.appendChild(run1);
+  body.appendChild(para1);
+
+  const para2 = xml.createElement("w:p");
+  const run2 = xml.createElement("w:r");
+  const t2 = xml.createElement("w:t");
+  t2.textContent = "Below is a sample pricing table:";
+  run2.appendChild(t2);
+  para2.appendChild(run2);
+  body.appendChild(para2);
+
+  const tbl = xml.createElement("w:tbl");
+  const grid = xml.createElement("w:tblGrid");
+  grid.appendChild(xml.createElement("w:gridCol"));
+  grid.appendChild(xml.createElement("w:gridCol"));
+  grid.appendChild(xml.createElement("w:gridCol"));
+  tbl.appendChild(grid);
+
+  const rowsData = [
+    ["Item", "Quantity", "Price"],
+    ["Widget A", "10", "$100.00"],
+    ["Widget B", "", "$250.00"], // Middle cell is empty!
+  ];
+
+  for (const rowCells of rowsData) {
+    const tr = xml.createElement("w:tr");
+    for (const value of rowCells) {
+      const tc = xml.createElement("w:tc");
+      const p = xml.createElement("w:p");
+      if (value) {
+        const r = xml.createElement("w:r");
+        const cellText = xml.createElement("w:t");
+        cellText.textContent = value;
+        r.appendChild(cellText);
+        p.appendChild(r);
+      }
+      tc.appendChild(p);
+      tr.appendChild(tc);
+    }
+    tbl.appendChild(tr);
+  }
+  body.appendChild(tbl);
+
+  writeFileSync(path, await doc.save());
+}
+
+describe("QA Regression Test - apply_text_revision rejection of read_docx payloads with empty cell anchors", () => {
+  let server: TestServer;
+  let docPath: string;
+  let outPath: string;
+
+  beforeAll(async () => {
+    server = await startTestServer("repro_empty_cell_anchor");
+    docPath = server.tempOut("doc_table.docx");
+    outPath = server.tempOut("doc_table_revised.docx");
+    await writeTableWithEmptyCellDoc(docPath);
+  }, 30000);
+
+  afterAll(() => {
+    server?.stop();
+  });
+
+  it("should apply text revision successfully on document with empty table cells", async () => {
+    // 1. Read the document using read_docx
+    const readRes = await server.callTool("read_docx", {
+      reasoning: "Reading document content before applying revision.",
+      file_path: docPath,
+      page: "all",
+    });
+
+    expect(readRes.isError).toBeFalsy();
+    const readText = readRes.content[0].text as string;
+
+    // Verify read_docx output contains empty table cell anchor
+    expect(readText).toMatch(/Widget B \| \{#cell:[0-9a-fA-F]{8}\} \| \$250\.00/);
+
+    // 2. Prepare revised text by making a minor edit in prose
+    const revisedText = readText.replace(
+      "Below is a sample pricing table:",
+      "Below is an updated pricing table:",
+    );
+
+    // 3. Apply text revision
+    const applyRes = await server.callTool("apply_text_revision", {
+      reasoning: "Updating pricing table introduction.",
+      file_path: docPath,
+      revised_text: revisedText,
+      output_path: outPath,
+    });
+
+    // Expect apply_text_revision to succeed without batch validation error
+    const resultText = applyRes.content[0].text as string;
+    expect(applyRes.isError, `apply_text_revision failed with error: ${resultText}`).toBeFalsy();
+    expect(resultText).toContain(`Saved to: ${outPath}`);
+    expect(existsSync(outPath)).toBe(true);
   });
 });

--- a/python/src/adeu/text_revision.py
+++ b/python/src/adeu/text_revision.py
@@ -143,9 +143,17 @@ def _extract_clean_text_from_doc(doc: Any) -> str:
     return str(res)
 
 
+def strip_cell_anchors(text: str) -> str:
+    """Strips synthetic {#cell:<paraId>} anchor tokens from clean-text payloads."""
+    text = re.sub(r"([^|])\s+\{#cell:[^}]+\}", r"\1", text)
+    text = re.sub(r"\{#cell:[^}]+\}", "", text)
+    return text
+
+
 def _normalize_virtual_projection_text(text: str) -> str:
-    """Normalizes Markdown heading chrome for clean-text verification."""
-    return re.sub(r"^#+\s*", "", text, flags=re.MULTILINE)
+    """Normalizes Markdown heading chrome and synthetic anchors for clean-text verification."""
+    text = re.sub(r"^#+\s*", "", text, flags=re.MULTILINE)
+    return strip_cell_anchors(text)
 
 
 def verify_clean_text(
@@ -214,7 +222,8 @@ def apply_text_revision_core(
 ) -> Tuple[Dict[str, Any], Path]:
     """Core whole-text diff->tracked-changes primitive with clean-text verification gate."""
     p_input = Path(file_path)
-    text_clean_input, page, total = _strip_page_chrome(revised_text)
+    raw_text_clean, page, total = _strip_page_chrome(revised_text)
+    text_clean_input = strip_cell_anchors(raw_text_clean)
     if total is not None and total > 1:
         raise ValueError(
             f"Text revision looks like page {page or '?'} of {total} of a paginated extract — "

--- a/python/tests/test_mcp_apply_text_revision.py
+++ b/python/tests/test_mcp_apply_text_revision.py
@@ -364,3 +364,10 @@ def test_cli_text_apply_batch_rejection_json_is_a_failure_envelope(tmp_path, cap
     envelope = json.loads(stdout)
     assert envelope["error"] == "batch_validation_failed"
     assert not out.exists()
+
+
+def test_strip_cell_anchors():
+    from adeu.text_revision import strip_cell_anchors
+
+    assert strip_cell_anchors("Widget B | {#cell:05856B27} | $250.00") == "Widget B |  | $250.00"
+    assert strip_cell_anchors("Widget B | Audit {#cell:05856B27} | $250.00") == "Widget B | Audit | $250.00"


### PR DESCRIPTION
…oads

## Pull Request Overview

Please provide a brief description of the changes introduced by this PR.

---

## 🛑 Ecosystem / Vendor Integrations (READ FIRST)
*If you are submitting a new third-party integration, API connector, or LegalTech tool to the `ecosystem/` directory, you **must** complete this checklist. PRs that fail to meet these criteria will be automatically closed without review.*

- [ ] **Zero Core Coupling:** I confirm this PR does NOT modify `src/adeu/` or `node/packages/core/`. All execution logic is self-contained or strictly uses approved callback/middleware hooks.
- [ ] **Strict Dependency Isolation:** I have included a dedicated package manager file (`pyproject.toml` or `package.json`) exclusively within my `ecosystem/<plugin>/` directory. My dependencies do not pollute the root lockfiles.
- [ ] **No Hoisting / Phantom Dependencies:** I am using explicit workspace protocols (e.g., `workspace:*` or `adeu = { path = "../../python" }`) to reference the core engine.
- [ ] **Commercial Transparency:** If my integration requires a paid subscription, API key, or routes to a closed-source endpoint, it is explicitly declared at the very top of my `README.md`.
- [ ] **14-Day Maintenance SLA:** I have read and agree to the `VENDOR_POLICY.md`. I acknowledge that I am responsible for the perpetual OpEx of this code. If this integration breaks and I fail to resolve the issue within 14 days, I understand the integration will be aggressively pruned/deleted.

---

## 🛠️ Core Engine Contributions
*If you are contributing to the core Adeu OpenXML parsing engine or standard MCP tooling:*

- [ ] I have added a regression test (e.g., `tests/test_repro_issue_name.py`) to prove the bug is fixed or the feature handles Edge-Case OpenXML correctly.
- [ ] I have verified that changes to `RedlineEngine` do not cause silent DOM corruption (e.g., bypassing `w:ins`/`w:del` tags).
- [ ] I have run the formatting and linting suite (`uv run ruff format .` and `uv run mypy src`).
- [ ] (If applicable) I have tested this against Live MS Word via COM (`live_word.py`) to ensure parity between Disk and Live operations.

## Related Issues
Closes # (Issue Number)